### PR TITLE
EXEC (func 0x4b): fix: do not crash if exMinAlloc == 0xffff

### DIFF
--- a/kernel/task.c
+++ b/kernel/task.c
@@ -587,6 +587,12 @@ COUNT DosExeLoader(BYTE FAR * namep, exec_blk * exp, COUNT mode, COUNT fd)
       image_size += sizeof(psp) / 16;        /* TE 03/20/01 */
       exe_size = image_size + ExeHeader.exMinAlloc;
       
+      /* Some ancient NE programs set exMinAlloc to 0xffff to signify
+         that they should not be run as normal MZ programs at all.  Check
+         for this and similar conditions. -- 2019/11/05 tkchia */
+      if (exe_size < image_size)
+        return DE_NOMEM;
+      
       /* Clone the environement and create a memory arena     */
       if (mode & 0x80)
       {


### PR DESCRIPTION
Some ancient "New Executable" (`NE`) programs set `exMinAlloc` in the `MZ` header to `0xffff`, to signify that they should not be run as normal `MZ` programs at all:
```
00000000  4d 5a 40 00 01 00 00 00  04 00 ff ff ff ff 00 00
00000010  00 00 00 00 00 00 00 00  40 00 00 00 00 00 00 00
00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
00000030  00 00 00 00 00 00 00 00  00 00 00 00 40 00 00 00
00000040  4e 45 04 00 9b 00 07 00  00 00 00 00 06 40 02 00
...
```
The kernel should reject these programs, rather than try to run them (and crash the system).