### PR TITLE
 Function 30h (Get DOS Version): Get DOS version from PSP

### DIFF
--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -726,12 +726,14 @@ dispatch:
 
       /* Get (editable) DOS Version                                   */
     case 0x30:
+    {
+      psp FAR *p = MK_FP(cu_psp, 0);
+
       if (lr.AL == 1) /* from RBIL, if AL=1 then return version_flags */
           lr.BH = version_flags;
       else
           lr.BH = OEM_ID;
-      lr.AL = os_setver_major;
-      lr.AH = os_setver_minor;
+      lr.AX = p->ps_retdosver;
       lr.BL = REVISION_SEQ;
       lr.CX = 0; /* do not set this to a serial number!
                     32RTM won't like non-zero values   */
@@ -761,8 +763,9 @@ dispatch:
         }
 
       }
+    }
 
-      break;
+    break;
 
       /* Keep Program (Terminate and stay resident) */
     case 0x31:

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -188,6 +188,8 @@ void new_psp(seg para, seg cur_psp)
   p->ps_isv24 = getvec(0x24);
   /* parent psp segment set to 0 (see RBIL int21/ah=26)   */
   p->ps_parent = 0;
+  /* default system version for int21/ah=30               */
+  p->ps_retdosver = (os_setver_minor << 8) + os_setver_major;
 }
 
 void child_psp(seg para, seg cur_psp, int psize)


### PR DESCRIPTION
  - Upon creation, initialize the PSP version field to os_setver_minor / os_setver_major.
  - When calling Function 30h, return the contents of the current PSP's version field to the caller.