### PR TITLE
Travis: Initial build attempt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 * text eol=crlf
 *.up -text
 *.UP -text
+travis_*.sh text eol=lf
+.travis.yml text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: c
+
+dist:  bionic
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:dosemu2/ppa'
+      - sourceline: 'ppa:stsp-0/djgpp'
+      - sourceline: 'ppa:tkchia/build-ia16'
+    packages:
+      - gcc-ia16-elf
+      - nasm
+      - upx
+    update: true
+
+before_install:
+  - echo "before_install"
+
+install:
+  - ./travis_build.sh
+
+before_script:
+  - echo "before_script"
+
+script:
+  - ./travis_test.sh

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+make all COMPILER=gcc
+

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -f kernel/kernel.sys ] ; then
+  echo Kernel has been built
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Automatic building of FreeDOS with the GCC compiler using [Travis](https://travis-ci.com/) upon every push or PR. If you have a test suite, then automatic testing can be added too.
