### PR TITLE
Fix call interfaces around int2F_12_handler( ), syscall_MUX14( ), and (mostly) int21_syscall( )

### DIFF
--- a/hdr/pcb.h
+++ b/hdr/pcb.h
@@ -87,14 +87,6 @@ typedef struct {
   UWORD si, di, ds, es;
 } lregs;
 
-   /* Registers directly passed to syscall;
-      must be the same order as iregs!
-      Is used to define parameters. */
-#define DIRECT_IREGS   \
-   xreg a, xreg b, xreg c, xreg d, \
-   UWORD si, UWORD di, UWORD bp, UWORD ds, UWORD es,   \
-   UWORD ip, UWORD cs, UWORD flags
-
 /* Process control block for task switching                             */
 typedef struct {
   UWORD pc_ss;

--- a/kernel/entry.asm
+++ b/kernel/entry.asm
@@ -236,6 +236,10 @@ reloc_call_int20_handler:
 ;       int21_handler(iregs UserRegs)
 ;
 reloc_call_int21_handler:
+                cmp     ah,25h
+                je      int21_func25
+                cmp     ah,35h
+                je      int21_func35
                 ;
                 ; Create the stack frame for C call.  This is done to
                 ; preserve machine state and provide a C structure for
@@ -262,11 +266,7 @@ int21_reentry:
                 mov     dx,[cs:_DGROUP_]
                 mov     ds,dx
 
-                cmp     ah,25h
-                je      int21_user
                 cmp     ah,33h
-                je      int21_user
-                cmp     ah,35h
                 je      int21_user
                 cmp     ah,50h
                 je      int21_user
@@ -284,6 +284,29 @@ int21_user:
                 pop     cx
                 pop     cx
                 jmp     short int21_ret
+
+int21_func25:
+                push    es
+                push    bx
+                xor     bx,bx
+                mov     es,bx
+                mov     bl,al
+                shl     bx,1
+                shl     bx,1
+                mov     [es:bx],dx
+                mov     [es:bx+2],ds
+                pop     bx
+                pop     es
+                iret
+
+int21_func35:
+                xor     bx,bx
+                mov     es,bx
+                mov     bl,al
+                shl     bx,1
+                shl     bx,1
+                les     bx,[es:bx]
+                iret
 
 ;
 ; normal entry, use one of our 4 stacks

--- a/kernel/int2f.asm
+++ b/kernel/int2f.asm
@@ -149,8 +149,9 @@ Int2f?14:      ;; MUX-14 -- NLSFUNC API
                push bp                 ; Preserve BP later on
                Protect386Registers
                PUSH$ALL
-               mov ds, [cs:_DGROUP_]
+               SwitchToInt2fStack
                call _syscall_MUX14
+               DoneInt2fStack
                pop bp                  ; Discard incoming AX
                push ax                 ; Correct stack for POP$ALL
                POP$ALL

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1734,13 +1734,14 @@ struct int2f12regs {
   UWORD callerARG1;             /* used if called from INT2F/12 */
 };
 
-/* WARNING: modifications in `r' are used outside of int2F_12_handler()
- * On input r.AX==0x12xx, 0x4A01 or 0x4A02
+/* On input pr->AX==0x12xx, 0x4A01 or 0x4A02
  */
-VOID ASMCFUNC int2F_12_handler(struct int2f12regs r)
+VOID ASMCFUNC int2F_12_handler(struct int2f12regs FAR *pr)
 {
   COUNT rc;
   long lrc;
+
+#define r (*pr)
 
   if (r.AH == 0x4a)
   {
@@ -2111,6 +2112,8 @@ error_exit:
     CritErrCode = r.AX;      /* Maybe set */
 error_carry:
   r.FLAGS |= FLG_CARRY;
+
+#undef r
 }
 
 /*

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -812,6 +812,11 @@ blk_stk_top:
                 times 128 dw 0
 clk_stk_top:
 
+; int2fh private stack
+                global  int2f_stk_top
+                times 128 dw 0
+int2f_stk_top:
+
 ; Dynamic data:
 ; member of the DOS DATA GROUP
 ; and marks definitive end of all used data in kernel data segment

--- a/kernel/nls.c
+++ b/kernel/nls.c
@@ -667,60 +667,54 @@ VOID FAR *DosGetDBCS(void)
 	Return value: AL register to be returned
 		if AL == 0, Carry must be cleared, otherwise set
 */
-UWORD ASMCFUNC syscall_MUX14(DIRECT_IREGS)
+UWORD ASMCFUNC syscall_MUX14(iregs FAR *pr)
 {
   struct nlsPackage FAR *nls;   /* addressed NLS package */
 
-  UNREFERENCED_PARAMETER(flags);
-  UNREFERENCED_PARAMETER(cs);
-  UNREFERENCED_PARAMETER(ip);
-  UNREFERENCED_PARAMETER(ds);
-  UNREFERENCED_PARAMETER(es);
-  UNREFERENCED_PARAMETER(si);
+  log(("NLS: MUX14(): subfct=%x, cp=%u, cntry=%u\n", pr->AL, pr->BX, pr->DX));
 
-  log(("NLS: MUX14(): subfct=%x, cp=%u, cntry=%u\n", AL, BX, DX));
-
-  if ((nls = searchPackage(BX, DX)) == NULL)
+  if ((nls = searchPackage(pr->BX, pr->DX)) == NULL)
     return DE_INVLDFUNC;        /* no such package */
 
   log(("NLS: MUX14(): NLS pkg found\n"));
 
-  switch (AL)
+  switch (pr->AL)
   {
     case NLSFUNC_INSTALL_CHECK:
-      BX = NLS_FREEDOS_NLSFUNC_ID;
+      pr->BX = NLS_FREEDOS_NLSFUNC_ID;
       return SUCCESS;           /* kernel just simulates default functions */
     case NLSFUNC_DOS38:
-      return nlsGetData(nls, NLS_DOS_38, MK_FP(ES, DI), 34);
+      return nlsGetData(nls, NLS_DOS_38, MK_FP(pr->ES, pr->DI), 34);
     case NLSFUNC_GETDATA:
-      return nlsGetData(nls, BP, MK_FP(ES, DI), CX);
+      return nlsGetData(nls, pr->BP, MK_FP(pr->ES, pr->DI), pr->CX);
     case NLSFUNC_DRDOS_GETDATA:
       /* Does not pass buffer length */
-      return nlsGetData(nls, CL, MK_FP(ES, DI), 512);
+      return nlsGetData(nls, pr->CL, MK_FP(pr->ES, pr->DI), 512);
     case NLSFUNC_LOAD_PKG:
       return nlsLoadPackage(nls);
     case NLSFUNC_LOAD_PKG2:
       return nlsSetPackage(nls);
     case NLSFUNC_YESNO:
-      return nlsYesNo(nls, CX);
+      return nlsYesNo(nls, pr->CX);
     case NLSFUNC_UPMEM:
-      nlsUpMem(nls, MK_FP(ES, DI), CX);
+      nlsUpMem(nls, MK_FP(pr->ES, pr->DI), pr->CX);
       return SUCCESS;
     case NLSFUNC_FILE_UPMEM:
 #ifdef NLS_DEBUG
       {
         unsigned j;
         BYTE FAR *p;
-        log(("NLS: MUX14(FILE_UPMEM): len=%u, %04x:%04x=\"", CX, ES, DI));
-        for (j = 0, p = MK_FP(ES, DI); j < CX; ++j)
+        log(("NLS: MUX14(FILE_UPMEM): len=%u, %04x:%04x=\"", pr->CX,
+                                                             pr->ES, pr->DI));
+        for (j = 0, p = MK_FP(pr->ES, pr->DI); j < pr->CX; ++j)
           printf("%c", p[j] > 32 ? p[j] : '.');
         printf("\"\n");
       }
 #endif
-      nlsFUpMem(nls, MK_FP(ES, DI), CX);
+      nlsFUpMem(nls, MK_FP(pr->ES, pr->DI), pr->CX);
       return SUCCESS;
   }
-  log(("NLS: MUX14(): Invalid function %x\n", AL));
+  log(("NLS: MUX14(): Invalid function %x\n", pr->AL));
   return DE_INVLDFUNC;          /* no such function */
 }
 

--- a/kernel/proto.h
+++ b/kernel/proto.h
@@ -277,7 +277,7 @@ COUNT DosSetCountry(UWORD cntry);
 COUNT DosGetCodepage(UWORD * actCP, UWORD * sysCP);
 COUNT DosSetCodepage(UWORD actCP, UWORD sysCP);
 VOID FAR *DosGetDBCS(void);
-UWORD ASMCFUNC syscall_MUX14(DIRECT_IREGS);
+UWORD ASMCFUNC syscall_MUX14(iregs FAR *);
 
 /* prf.c */
 #ifdef DEBUG


### PR DESCRIPTION
This changes the interface between `reloc_call_int2f_handler` (`int2f.asm`) and `int2F_12_handler( )` (`inthndlr.c`) so that

  * `int2F_12_handler( )` will not try to output values to its caller by passing "back" input parameter values
  * `reloc_call_int2f_handler` will switch to an internal stack before calling `int2F_12_handler( )`, so that `SS` == `DGROUP` as expected by the latter.

This partly addresses https://github.com/FDOS/kernel/issues/11 .

(The call to `syscall_MUX14( )` in `int2f.asm` seems to have similar issues, and should probably also be updated.)