### PR TITLE
Make: Allow clean and clobber to work with gcc

### DIFF
--- a/makefile
+++ b/makefile
@@ -115,16 +115,20 @@ all:
 	cd boot && $(MAKE) production
 	cd sys && $(MAKE) production
 	cd kernel && $(MAKE) production
+	$(MAKEREMOVE)
 
 clean:
+	$(MAKEADJUST)
 	cd utils && $(MAKE) clean
 	cd lib && $(MAKE) clean
 	cd drivers && $(MAKE) clean
 	cd boot && $(MAKE) clean
 	cd sys && $(MAKE) clean
 	cd kernel && $(MAKE) clean
+	$(MAKEREMOVE)
 
 clobber:
+	$(MAKEADJUST)
 	cd utils && $(MAKE) clobber
 	cd lib && $(MAKE) clobber
 	cd drivers && $(MAKE) clobber


### PR DESCRIPTION
Currently the sed trickery for gcc is only setup on the all target, but
if we want to do `make COMPILER=gcc clean all` the clean will fail.
Setup and remove the GNUmakefiles for each main target.