### PR TITLE
Fix Func 30h (Get DOS Version) return version 0.0 in config.sys

### DIFF
--- a/kernel/config.c
+++ b/kernel/config.c
@@ -1240,6 +1240,7 @@ STATIC VOID sysVersion(BYTE * pLine)
 
   LoL->os_setver_major = major; /* not the internal os_major */
   LoL->os_setver_minor = minor; /* not the internal os_minor */
+  ((psp far *)MK_FP(DOS_PSP, 0))->ps_retdosver = (minor << 8) + major;
 }
 
 STATIC VOID Files(BYTE * pLine)

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -200,6 +200,9 @@ STATIC void PSPInit(void)
   /* open file table pointer                              */
   p->ps_filetab = p->ps_files;
 
+  /* default system version for int21/ah=30               */
+  p->ps_retdosver = (LoL->os_setver_minor << 8) + LoL->os_setver_major;
+
   /* first command line argument                          */
   /* p->ps_fcb1.fcb_drive = 0; already set                */
   fmemset(p->ps_fcb1.fcb_fname, ' ', FNAME_SIZE + FEXT_SIZE);


### PR DESCRIPTION
* Add initialization of the PSP in processing the CONFIG.SYS