### PR TITLE
Fix func 0Bh (Get STDIN Status) always returns AL=FFh with some alter…

### DIFF
--- a/kernel/chario.c
+++ b/kernel/chario.c
@@ -96,7 +96,9 @@ STATIC void CharCmd(struct dhdr FAR **pdev, unsigned command)
 
 STATIC int Busy(struct dhdr FAR **pdev)
 {
-  CharCmd(pdev, C_ISTAT);
+  CharCmd(pdev, C_NDREAD);
+  if (CharReqHdr.r_status & S_ERROR)
+    CharCmd(pdev, C_ISTAT);
   return CharReqHdr.r_status & S_BUSY;
 }
 


### PR DESCRIPTION
…native CON drivers:

* qwikansi.sys (simtelnet: simtelnet/msdos/screen/qwikansi.zip)
* most of Japanese input methods (Microsoft MS-IME, ATOK, WXP/WX2/WX3)