### PR TITLE
Travis: Build and test with both GCC and Watcom

### DIFF
--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,4 +1,30 @@
 #!/bin/sh
 
-make all COMPILER=gcc
+if [ -z "${TRAVIS_BUILD_DIR}" ] ; then
+  TRAVIS_BUILD_DIR=$(pwd)
+fi
+echo TRAVIS_BUILD_DIR is \"${TRAVIS_BUILD_DIR}\"
 
+# Output directory
+rm -rf _output
+mkdir _output
+
+# GCC
+git clean -x -d -f -e _output -e _watcom -e ow-snapshot.tar.gz
+make all COMPILER=gcc
+mv -i bin/KGC*.map bin/KGC*.sys _output/.
+
+# Watcom
+if [ ! -d _watcom ] ; then
+  [ -f ow-snapshot.tar.gz ] || wget https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/ow-snapshot.tar.gz
+
+  mkdir _watcom
+  (cd _watcom && tar -xf ../ow-snapshot.tar.gz)
+fi
+
+export PATH=$TRAVIS_BUILD_DIR/bin:$PATH:$TRAVIS_BUILD_DIR/_watcom/binl64
+export WATCOM=$TRAVIS_BUILD_DIR/_watcom
+
+git clean -x -d -f -e _output -e _watcom -e ow-snapshot.tar.gz
+make all COMPILER=owlinux
+mv -i bin/KWC*.map bin/KWC*.sys _output/.

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 
-if [ -f kernel/kernel.sys ] ; then
-  echo Kernel has been built
-  exit 0
+KVER=8632
+
+if [ ! -f _output/KGC${KVER}.sys ] ; then
+  echo GCC built kernel not present
+  exit 1
 fi
 
-exit 1
+if [ ! -f _output/KWC${KVER}.sys ] ; then
+  echo Watcom built kernel not present
+  exit 1
+fi
+
+echo GCC and Watcom kernels have all been built
+ls -l _output/K*
+exit 0


### PR DESCRIPTION
Watcom compiler is downloaded and extracted if necessary. On Travis this
will be always, but if you build locally multiple times using
./travis_build, it will use the previous watcom installation.