### PR TITLE
ia16-elf-gcc: use new SS != DGROUP support for int21_syscall( )

### DIFF
--- a/docs/build.txt
+++ b/docs/build.txt
@@ -37,8 +37,8 @@ You can now also cross compile with T.K. Chia's fork of ia16-elf-gcc,
 which is available at https://github.com/tkchia/gcc-ia16, using
 make all COMPILER=gcc
 or by setting COMPILER=gcc in config.mak. If you are using Ubuntu
-Linux 16.04 LTS (Xenial Xerus) or Ubuntu Linux 14.04 LTS (Trusty
-Tahr), there are precompiled ia16-elf-gcc packages at
+Linux 20.04 LTS (Focal Fossa), 18.04 (Bionic Beaver), or 16.04 LTS
+(Xenial Xerus), there are precompiled ia16-elf-gcc packages at
 https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16/.
 Otherwise, for now ia16-elf-gcc needs to be compiled from source.
 Only releases 20180708 and later are supported.


### PR DESCRIPTION
Changes:
  * I recently [added to my `gcc-ia16` toolchain](https://github.com/tkchia/build-ia16/releases/tag/20200321) some support for compiling functions to run with the stack outside of the data segment (`%ss` ≠ `.data`).  In the first commit, I modify `int21_syscall( )` --- which implements `int $0x21` functions that do not switch to DOS's internal stacks --- so that it uses this compiler feature if available.
  * The second commit updates `docs/build.txt` on the Ubuntu distributions for which pre-compiled `gcc-ia16` toolchains are available.

Thank you!