### PR TITLE
correct I186 and I386 macros definition

### DIFF
--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -132,7 +132,9 @@ unsigned short getSS(void);
 #pragma enable_message(130)
 
 #if _M_IX86 >= 300 || defined(M_I386)
+#ifndef I386
 #define I386
+#endif
 #endif
 
 #elif defined (_MYMC68K_COMILER_)
@@ -185,9 +187,13 @@ We might even deal with a pre-ANSI compiler. This will certainly not compile.
 
 #ifdef I86
 #if _M_IX86 >= 300 || defined(M_I386)
+#ifndef I386
 #define I386
+#endif
 #elif _M_IX86 >= 100 || defined(M_I286)
+#ifndef I186
 #define I186
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
correct I186 and I386 macros definition to work with all Open Watcom toolchain versions
command line definition macro has "1" value but in header file it is defined as blank value
anyway I86/I186/I386 macros usage is not transparent, it is definition duplicity in header file and on command line
it is wrong solution even if it works on most of compilers (command line macro re-definition is hidden)