### PR TITLE
boot: fix Int10.0E expected not to alter al (SBC188)

### DIFF
--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -355,18 +355,19 @@ load_next:      dec     ax                      ; cluster numbers start with 2
 
 ; shows text after the call to this function.
 
+show.do_show:
+                mov     ah, 0Eh                 ; show character
+                int     10h                     ; via "TTY" mode
 show:           pop     si
                 lodsb                           ; get character
                 push    si                      ; stack up potential return address
-                mov     ah,0x0E                 ; show character
-                int     0x10                    ; via "TTY" mode
-                cmp     al,'.'                  ; end of string?
-                jne     show                    ; until done
+                cmp     al, 0                   ; end of string?
+                jne     .do_show                ; until done
                 ret
 
 boot_error:     call    show
-;                db      "Error! Hit a key to reboot."
-                db      "Error!."
+;                db      "Error! Hit a key to reboot.",0
+                db      "Error!",0
 
                 xor     ah,ah
                 int     0x13                    ; reset floppy
@@ -391,7 +392,7 @@ readDisk:       push    si
                 mov     word [READADDR_OFF], bx
 
                 call    show
-                db      "."
+                db      ".",0
 read_next:
 
 ;******************** LBA_READ *******************************

--- a/boot/oemboot.asm
+++ b/boot/oemboot.asm
@@ -460,8 +460,8 @@ cluster_next:   lodsw                   ; AX = next cluster to read
 ; failed to boot
 boot_error:     
 call            show
-;               db      "Error! Hit a key to reboot."
-                db      "):."
+;               db      "Error! Hit a key to reboot.",0
+                db      "):",0
 %ifdef LOOPONERR
 jmp $
 %else
@@ -488,13 +488,14 @@ load_next:      dec     ax                      ; cluster numbers start with 2
 
 ; shows text after the call to this function.
 
+show.do_show:
+                mov     ah, 0Eh                 ; show character
+                int     10h                     ; via "TTY" mode
 show:           pop     si
                 lodsb                           ; get character
                 push    si                      ; stack up potential return address
-                mov     ah,0x0E                 ; show character
-                int     0x10                    ; via "TTY" mode
-                cmp     al,'.'                  ; end of string?
-                jne     show                    ; until done
+                cmp     al, 0                   ; end of string?
+                jne     .do_show                ; until done
                 ret
 
 
@@ -516,7 +517,7 @@ readDisk:       push    si                      ; preserve cluster #
                 mov     word [LBA_OFF], bx
 
                 call    show
-                db      "."
+                db      ".",0
 read_next:
 
 ; initialize constants


### PR DESCRIPTION
Reference: https://www.bttr-software.de/forum/forum_entry.php?id=16934

The SBC188 video ROM-BIOS handling returns with al=0Ah (LF)
upon interrupt 10h function 0Eh calls that scroll the screen.
This made the FAT12 boot loader crash when booting FreeDOS
off a 1440 KiB diskette. While a fix is expected from their
side too, hardening the loader too is the right thing to do.

With the way this fix is implemented by this commit, it only
needs one additional byte for the loader. The error message
changes from "Error!." to just "Error!", other than
that the behaviour is the same.

The FAT32 loaders already used zero-terminated strings and
thus were not affected by the dependence.