### PR TITLE
boot: allow instsect to match the filesystem ID string

### DIFF
--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -100,7 +100,20 @@ Entry:          jmp     short real_start
 
 ;-----------------------------------------------------------------------
 
-                times   0x3E-$+$$ db 0
+                times   36h - ($ - $$) db 0
+                ; The filesystem ID is used by lDOS's instsect (by ecm)
+                ;  by default to validate that the filesystem matches.
+%ifdef ISFAT12
+                db "FAT12"
+ %ifdef ISFAT16
+ %error Must select one FS
+ %endif
+%elifdef ISFAT16
+                db "FAT16"
+%else
+ %error Must select one FS
+%endif
+                times   3Eh - ($ - $$) db 32
 
 ; using bp-Entry+loadseg_xxx generates smaller code than using just
 ; loadseg_xxx, where bp is initialized to Entry, so bp-Entry equals 0

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -57,11 +57,16 @@ Entry:          jmp     short real_start
 %define xrootClst       bp+0x2c      ; Starting cluster of root directory
 %define drive           bp+0x40      ; Drive number
 
-		times	0x5a-$+$$ db 0
+		times   52h - ($ - $$) db 0
+		; The filesystem ID is used by lDOS's instsect (by ecm)
+		;  by default to validate that the filesystem matches.
+		db "FAT32"
+		times   5Ah - ($ - $$) db 32
+
 
 %define LOADSEG         0x0060
 
-%define FATSEG          0x2000         
+%define FATSEG          0x2000
 
 %define fat_sector      bp+0x48         ; last accessed sector of the FAT
 

--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -96,7 +96,11 @@ Entry:		jmp	short real_start
 %define data_start	bp+0x4c		; first data sector (dd)
 					; (overwriting unused bytes)
 
-		times	0x5a-$+$$ db 0
+		times   52h - ($ - $$) db 0
+		; The filesystem ID is used by lDOS's instsect (by ecm)
+		;  by default to validate that the filesystem matches.
+		db "FAT32"
+		times   5Ah - ($ - $$) db 32
 		; not used: [0x42] = byte 0x29 (ext boot param flag)
 		; [0x43] = dword serial
 		; [0x47] = label (padded with 00, 11 bytes)

--- a/boot/oemboot.asm
+++ b/boot/oemboot.asm
@@ -223,7 +223,20 @@ Entry:          jmp     short real_start
                 db 0x29         ; extended boot record id
                 dd 0x12345678   ; volume serial number
                 db 'NO NAME    '; volume label
-                db 'FAT12   '   ; filesystem id
+                times   36h - ($ - $$) db 0
+                ; The filesystem ID is used by lDOS's instsect (by ecm)
+                ;  by default to validate that the filesystem matches.
+%ifdef ISFAT12
+                db "FAT12"     ; filesystem id
+ %ifdef ISFAT16
+ %error Must select one FS
+ %endif
+%elifdef ISFAT16
+                db "FAT16"
+%else
+ %error Must select one FS
+%endif
+                times   3Eh - ($ - $$) db 32
 
 ;-----------------------------------------------------------------------
 ;   ENTRY


### PR DESCRIPTION
Reference: https://hg.ulukai.org/ecm/instsect/file/33218c729b43/instsect.asm#l1257

lDOS's instsect recently started to default to checking
the filesystem ID string in order to validate that the
boot sector loader to write matches the detected FS.
Using the /S=filename option or building instsect to
include the FreeDOS kernel's loaders would require use
of the /SN switch without this commit.

In addition, boot.asm and oemboot.asm are made to check
that exactly one of the ISFAT12 and ISFAT16 defs is
defined so as to select the FS. Prior to this commit
using both or neither def would silently result in a
broken loader.