### PR TITLE
FATFS: rmdir of read only directories is valid

### DIFF
--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -463,8 +463,9 @@ COUNT dos_rmdir(BYTE * path)
     return DE_PATHNOTFND;
 
   /* Directories may have attributes, but if other than 'archive'      */
-  /* then do not allow (RDONLY|SYSTEM|HIDDEN) directory to be deleted. */
-  if (fnp->f_dir.dir_attrib & ~(D_DIR |D_ARCHIVE))
+  /* or 'read only' then deny i.e. do not allow (SYSTEM|HIDDEN)        */
+  /* directory to be deleted.                                          */
+  if (fnp->f_dir.dir_attrib & ~(D_DIR | D_RDONLY | D_ARCHIVE))
     return DE_ACCESS;
 
   dir_read(fnp);


### PR DESCRIPTION
After comparison with DR-DOS 7.01 and MS-DOS 6.22 over at Dosemu2 it
was seen that rmdir of a directory having the _A_RDONLY bit set should
succeed. This patch makes that change.

For reference the test report can be found in the fdpp issue
https://github.com/dosemu2/fdpp/issues/161. An identical patch has been applied there.