### PR TITLE
CI: Update workflow and readme badge

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,11 +1,17 @@
-name: Build / Test / Upload snapshot
-
+name: Build
 on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - synchronize
   push:
-    branches: [ master ]
 
 jobs:
   build:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
 
     runs-on: ubuntu-20.04
 
@@ -34,6 +40,8 @@ jobs:
         )
 
     - name: upload
+      if: github.repository == 'FDOS/kernel' &&
+        (github.event_name == 'push' || github.event.pull_request.merged == true)
       uses: actions/upload-artifact@v2
       with:
         name: ${{ steps.snapshotname.outputs.fname }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This version of the kernel is intended only for 8086+ or 80386+ IBM compatible c
 Please feel free to email me - PerditionC@gmail.com
 2020
 
+[![Build](../../workflows/Build/badge.svg)](../../actions)
 
 [![Build Status](https://travis-ci.com/FDOS/kernel.svg?branch=master)](https://travis-ci.com/FDOS/kernel)
 Now with automatic builds and soon tests on [Travis CI](http://travis-ci.com)


### PR DESCRIPTION
Adds the build status badge, support for the '[skip ci]' keyword in the commit message and only upload build artefacts from the master repo/branch.  