### PR TITLE
task: don't zero parent_psp on 0x26

### DIFF
--- a/kernel/task.c
+++ b/kernel/task.c
@@ -224,8 +224,13 @@ void new_psp(seg para, seg cur_psp)
   p->ps_isv23 = getvec(0x23);
   /* critical error address                               */
   p->ps_isv24 = getvec(0x24);
+  /* RBIL is wrong on zeroing parent_psp, and in fact some
+   * progs (Alpha Waves game, https://github.com/stsp/fdpp/issues/112)
+   * won't work if its zeroed. */
+#if 0
   /* parent psp segment set to 0 (see RBIL int21/ah=26)   */
   p->ps_parent = 0;
+#endif
   /* default system version for int21/ah=30               */
   p->ps_retdosver = (os_setver_minor << 8) + os_setver_major;
 }


### PR DESCRIPTION
Patch ported from
  * https://github.com/dosemu2/fdpp/commit/f49252ac6b89a7bee0dd5ac90b9509918c19dd33

See
  * https://github.com/dosemu2/fdpp/issues/112
  * https://github.com/FDOS/kernel/issues/38