### PR TITLE
Share 03

### DIFF
--- a/kernel/dosfns.c
+++ b/kernel/dosfns.c
@@ -46,7 +46,7 @@ BYTE share_installed = 0;
            code, so DOS simply negates this value and returns it in
            AX. */
 extern int ASMPASCAL
-           share_open_check(char * filename,            /* pointer to fully qualified filename */
+           share_open_check(const char FAR * filename,  /* pointer to fully qualified filename */
                             unsigned short pspseg,      /* psp segment address of owner process */
                             int openmode,       /* 0=read-only, 1=write-only, 2=read-write */
                             int sharemode);     /* SHARE_COMPAT, etc... */

--- a/kernel/dosfns.c
+++ b/kernel/dosfns.c
@@ -86,6 +86,13 @@ extern int ASMPASCAL
                              unsigned long len, /* length (in bytes) of region to lock or unlock */
                              int unlock);       /* one to unlock; zero to lock */
 
+        /* DOS calls this to see if share already has the file marked as open.
+           Returns:
+             1 if open
+             0 if not */
+extern int ASMPASCAL
+            share_is_file_open(const char far * filename);
+
 /* /// End of additions for SHARE.  - Ron Cemer */
 
 STATIC int remote_lock_unlock(sft FAR *sftp,    /* SFT for file */
@@ -1214,6 +1221,9 @@ COUNT DosDelete(BYTE FAR * path, int attrib)
   if (result & IS_DEVICE)
     return DE_FILENOTFND;
 
+  if (IsShareInstalled(TRUE) && share_is_file_open(PriPathName))
+    return DE_ACCESS;
+
   return dos_delete(PriPathName, attrib);
 }
 
@@ -1225,6 +1235,9 @@ COUNT DosRenameTrue(BYTE * path1, BYTE * path2, int attrib)
   }
   if (FP_OFF(current_ldt) == 0xFFFF || (current_ldt->cdsFlags & CDSNETWDRV))
     return network_redirector(REM_RENAME);
+
+  if (IsShareInstalled(TRUE) && share_is_file_open(path1))
+    return DE_ACCESS;
 
   return dos_rename(path1, path2, attrib);
 }

--- a/kernel/int2f.asm
+++ b/kernel/int2f.asm
@@ -258,7 +258,7 @@ SHARE_CHECK:
 ;           error.  If < 0 is returned, it is the negated error return
 ;           code, so DOS simply negates this value and returns it in
 ;           AX.
-; STATIC int share_open_check(char * filename,
+; STATIC int share_open_check(const char FAR * filename,
 ;				/* pointer to fully qualified filename */
 ;                            unsigned short pspseg,
 ;				/* psp segment address of owner process */
@@ -267,13 +267,17 @@ SHARE_CHECK:
 ;			     int sharemode) /* SHARE_COMPAT, etc... */
 		global SHARE_OPEN_CHECK
 SHARE_OPEN_CHECK:
-		mov	es, si		; save si
+		push	ds
+		pop	es		; save ds
+		mov     di, si          ; save si
 		pop	ax		; return address
-		popargs	si,bx,cx,dx	; filename,pspseg,openmode,sharemode;
+		popargs	{ds,si},bx,cx,dx; filename,pspseg,openmode,sharemode;
 		push	ax		; return address
 		mov	ax, 0x10a0
 		int	0x2f	     	; returns ax
-		mov	si, es		; restore si
+		mov     si, di          ; restore si
+		push	es
+		pop	ds		; restore ds
 		ret
 
 ;          DOS calls this to record the fact that it has successfully

--- a/kernel/int2f.asm
+++ b/kernel/int2f.asm
@@ -342,6 +342,25 @@ SHARE_LOCK_UNLOCK:
 		mov	ax,0x10a4
 		jmp	short share_common
 
+;           DOS calls this to see if share already has the file marked as open.
+;           Returns:
+;             1 if open
+;             0 if not
+; STATIC WORD share_is_file_open(const char far *filename) /* pointer to fully qualified filename */
+		global SHARE_IS_FILE_OPEN
+SHARE_IS_FILE_OPEN:
+		mov	si, ds
+		mov	es, si		; save ds
+		pop	ax		; save return address
+		pop	si		; filename
+		pop	ds		; SEG filename
+		push	ax		; restore return address
+		mov	ax, 0x10a6
+		int	0x2f	     	; returns ax
+		mov	si, es		; restore ds
+		mov	ds, si
+		ret
+
 ; Int 2F Multipurpose Remote System Calls
 ;
 ; added by James Tabor jimtabor@infohwy.com

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -114,6 +114,7 @@ SECTIONS
 		_share_close_file = SHARE_CLOSE_FILE;
 		_share_access_check = SHARE_ACCESS_CHECK;
 		_share_lock_unlock = SHARE_LOCK_UNLOCK;
+		_share_is_file_open = SHARE_IS_FILE_OPEN;
 		_call_nls = CALL_NLS;
 		_fl_reset = FL_RESET;
 		_fl_diskchanged = FL_DISKCHANGED;


### PR DESCRIPTION
Updates for kernel use of share, which allow more Dosemu2 tests to pass.

There are further updates, but they have been written to target MSDOS 6.22 share/lock compatibility. In the past FreeDOS has aimed to support DOS 7 semantics, so they may not be appropriate.