### PR TITLE
Build on FreeDOS and OpenWATCOM environment

### DIFF
--- a/kernel/makefile
+++ b/kernel/makefile
@@ -53,7 +53,21 @@ clean:
 
 # XXX: This is a very ugly way of linking the kernel, forced upon us by the
 # inability of Turbo `make' 2.0 to perform command line redirection. -- ror4
-
+ifeq ($(%OS_NAME),FreeDOS)
+ifeq ($(%COMPILER),WATCOM)
+$(TARGET).lnk: turboc.cfg makefile ../mkfiles/generic.mak ../mkfiles/$(COMPILER).mak
+		-$(RM) *.lnk
+		$(ECHOTO) $(TARGET).lnk  F { 
+		$(ECHOTO) $(TARGET).lnk $(OBJS1)
+		$(ECHOTO) $(TARGET).lnk $(OBJS2)
+		$(ECHOTO) $(TARGET).lnk $(OBJS3)
+		$(ECHOTO) $(TARGET).lnk $(OBJS4)
+		$(ECHOTO) $(TARGET).lnk $(OBJS5)
+		$(ECHOTO) $(TARGET).lnk $(OBJS6)
+		$(ECHOTO) $(TARGET).lnk $(OBJS7)
+		$(ECHOTO) $(TARGET).lnk $(OBJS8)
+		$(ECHOTO) $(TARGET).lnk  } L ..\lib\device.lib L ..\lib\libm.lib N kernel.exe		
+else
 $(TARGET).lnk: turboc.cfg makefile ../mkfiles/generic.mak ../mkfiles/$(COMPILER).mak
 		-$(RM) *.lnk
 		$(ECHOTO) $(TARGET).lnk $(OBJS1)+
@@ -67,7 +81,22 @@ $(TARGET).lnk: turboc.cfg makefile ../mkfiles/generic.mak ../mkfiles/$(COMPILER)
 		$(ECHOTO) $(TARGET).lnk kernel.exe
 		$(ECHOTO) $(TARGET).lnk kernel.map
 		$(ECHOTO) $(TARGET).lnk $(LIBS)
-
+endif
+else
+$(TARGET).lnk: turboc.cfg makefile ../mkfiles/generic.mak ../mkfiles/$(COMPILER).mak
+		-$(RM) *.lnk
+		$(ECHOTO) $(TARGET).lnk $(OBJS1)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS2)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS3)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS4)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS5)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS6)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS7)+
+		$(ECHOTO) $(TARGET).lnk $(OBJS8)
+		$(ECHOTO) $(TARGET).lnk kernel.exe
+		$(ECHOTO) $(TARGET).lnk kernel.map
+		$(ECHOTO) $(TARGET).lnk $(LIBS)
+endif
 #               *Individual File Dependencies*
 apisupt.obj:	apisupt.asm segs.inc			$(TARGET).lnk
 asmsupt.obj:	asmsupt.asm segs.inc			$(TARGET).lnk

--- a/mkfiles/generic.mak
+++ b/mkfiles/generic.mak
@@ -24,8 +24,6 @@ NASMFLAGS=$(NASMFLAGS) -DWITHFAT32
 NASM=$(XNASM)
 NASMFLAGS   = $(NASMFLAGS) -i../hdr/ -DXCPU=$(XCPU)
 
-LINK=$(XLINK)
-
 INITPATCH=@rem
 DIRSEP=\ #a backslash
 RM=..\utils\rmfiles
@@ -38,6 +36,8 @@ LOADSEG=0x60
 !endif
 
 !include "../mkfiles/$(COMPILER).mak"
+
+LINK=$(XLINK)
 
 !if $(CLDEF) == 0
 CLT=$(CL) $(CFLAGST) $(TINY) -I$(INCLUDEPATH)

--- a/mkfiles/watcom.mak
+++ b/mkfiles/watcom.mak
@@ -65,3 +65,8 @@ ALLCFLAGS=-I..$(DIRSEP)hdr $(TARGETOPT) $(ALLCFLAGS)-zq-os-s-e5-j-zl-zp1-wx-we-z
 INITCFLAGS=$(ALLCFLAGS)-ntINIT_TEXT-gTGROUP-ndI
 CFLAGS=$(ALLCFLAGS)-ntHMA_TEXT
 
+!ifeq $(%OS_NAME) FreeDOS
+!ifeq $(%COMPILER) WATCOM
+XLINK=$(XLINK) debug all op symfile format dos option map,statics,verbose
+!endif
+!endif


### PR DESCRIPTION
When you build the kernel on FreeDOS and OpenWATCOM(Ver1.9)
The linkage file(e.g. KWC38632.LNK) will be output as shown below.

```
kernel.obj entry.obj io.obj console.obj serial.obj printer.obj dsk.obj sysclk.obj+
asmsupt.obj execrh.obj nlssupt.obj procsupt.obj dosidle.obj int2f.obj nls_hc.obj+
apisupt.obj intr.obj irqstack.obj blockio.obj chario.obj systime.obj error.obj+
break.obj dosfns.obj fatdir.obj fatfs.obj fattab.obj fcbfns.obj inthndlr.obj+
ioctl.obj memmgr.obj task.obj newstuff.obj nls.obj network.obj+
prf.obj misc.obj strings.obj syspack.obj lfnapi.obj iasmsupt.obj memdisk.obj+
main.obj config.obj initoem.obj inithma.obj dyninit.obj iprf.obj+
initdisk.obj initclk.obj cpu.obj+
kernel.exe
kernel.map
..\lib\device.lib ..\lib\libm.lib
```
And fail link.

So I modified as follow.

```
F {
kernel.obj entry.obj io.obj console.obj serial.obj printer.obj dsk.obj sysclk.obj
asmsupt.obj execrh.obj nlssupt.obj procsupt.obj dosidle.obj int2f.obj nls_hc.obj
apisupt.obj intr.obj irqstack.obj blockio.obj chario.obj systime.obj error.obj
break.obj dosfns.obj fatdir.obj fatfs.obj fattab.obj fcbfns.obj inthndlr.obj
ioctl.obj memmgr.obj task.obj newstuff.obj nls.obj network.obj
prf.obj misc.obj strings.obj syspack.obj lfnapi.obj iasmsupt.obj memdisk.obj
main.obj config.obj initoem.obj inithma.obj dyninit.obj iprf.obj
initdisk.obj initclk.obj cpu.obj
} L ..\lib\device.lib L ..\lib\libm.lib N kernel.exe
```
