### PR TITLE
ecm 2022-05 (exeflat copies CONFIG block, add debugger config/support, add kernel command line with commands CONFIG/ALTCONFIG/OLDCONFIG, fix empty executable)

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -11,9 +11,11 @@ echo BUILD_DIR is \"${BUILD_DIR}\"
 rm -rf _output
 mkdir _output
 
+OWTAR=ow-snapshot.tar.xz
+
 # GCC
 mkdir _output/gcc
-git clean -x -d -f -e _output -e _watcom -e ow-snapshot.tar.gz
+git clean -x -d -f -e _output -e _watcom -e $OWTAR
 make -C country clean
 make all COMPILER=gcc
 mv -n bin/KGC*.map bin/KGC*.sys _output/gcc/.
@@ -25,17 +27,17 @@ mv -n share/share.map _output/gcc/.
 
 # Watcom
 if [ ! -d _watcom ] ; then
-  [ -f ow-snapshot.tar.gz ] || wget --quiet https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/ow-snapshot.tar.gz
+  [ -f $OWTAR ] || wget --no-verbose https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/$OWTAR
 
   mkdir _watcom
-  (cd _watcom && tar -xf ../ow-snapshot.tar.gz)
+  (cd _watcom && tar -xf ../$OWTAR)
 fi
 
 export PATH=$BUILD_DIR/bin:$PATH:$BUILD_DIR/_watcom/binl64
 export WATCOM=$BUILD_DIR/_watcom
 
 mkdir _output/wc
-git clean -x -d -f -e _output -e _watcom -e ow-snapshot.tar.gz
+git clean -x -d -f -e _output -e _watcom -e $OWTAR
 make -C country clean
 make all COMPILER=owlinux
 mv -n bin/KWC*.map bin/KWC*.sys _output/wc/.

--- a/hdr/kconfig.h
+++ b/hdr/kconfig.h
@@ -46,4 +46,8 @@ typedef struct _KernelConfig {
   unsigned short Version_Revision;
   unsigned short Version_Release;
 
+  unsigned char CheckDebugger;
+	/* 0 = do not check (assume absent),
+	   1 = do check by running breakpoint,
+	   2 = assume present */
 } KernelConfig;

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -62,7 +62,7 @@ STATIC struct MenuSelector MenuStruct[MENULINESMAX] BSS_INIT({0});
 
 int nMenuLine BSS_INIT(0);
 int MenuColor = -1;
-extern UBYTE kernel_command_line[256];
+extern char kernel_command_line[256];
 extern int kernel_command_line_length;
 
 STATIC void WriteMenuLine(struct MenuSelector *menu)
@@ -866,9 +866,9 @@ VOID DoConfig(int nPass)
     unsigned ii;
     static char commandbuffer[256];
     char * end = &kernel_command_line[kernel_command_line_length];
-    char * configfile = "";
-    char * altconfigfile = "fdconfig.sys";
-    char * oldconfigfile = "config.sys";
+    static char * configfile = "";
+    static char * altconfigfile = "fdconfig.sys";
+    static char * oldconfigfile = "config.sys";
     struct { char ** pointer; char const * command; }
       configcommands[] = {
         { &configfile, "CONFIG" },

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -69,6 +69,8 @@ __segment DosTextSeg = 0;
 struct lol FAR *LoL = &DATASTART;
 
 struct _KernelConfig InitKernelConfig = { 0xFF };
+UBYTE kernel_command_line[256] = { 0x00, 0xFF }; /* special none value */
+int kernel_command_line_length BSS_INIT(0);
 UBYTE debugger_present = 0xFF;	/* initialised in kernel.asm
 				   do NOT set 0 here or compiler may
 				   move it into bss that we zero out */
@@ -77,6 +79,7 @@ VOID ASMCFUNC FreeDOSmain(void)
 {
   unsigned char drv;
   unsigned char FAR *p;
+  char * pp;
 
 #ifdef _MSC_VER
   extern FAR prn_dev;
@@ -105,6 +108,22 @@ VOID ASMCFUNC FreeDOSmain(void)
 
   /* install DOS API and other interrupt service routines, basic kernel functionality works */
   setup_int_vectors();
+
+#ifdef DEBUG
+  /* printf must go after setup_int_vectors call */
+  if (kernel_command_line[0] == 0x00 && kernel_command_line[1] == 0xFF) {
+    printf("\nKERNEL: Command line is not specified.\n");
+  } else {
+    printf("\nKERNEL: Command line is \"%s\"\n", kernel_command_line);
+  }
+#endif
+
+  kernel_command_line_length = strlen(kernel_command_line);
+  for (pp = kernel_command_line; *pp; ++pp) {
+    if (*pp == ';') {
+      *pp = 0;
+    }
+  }
 
   /* check if booting from floppy/CD */
   CheckContinueBootFromHarddisk();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -68,8 +68,8 @@ __segment DosTextSeg = 0;
 
 struct lol FAR *LoL = &DATASTART;
 
-struct _KernelConfig InitKernelConfig = { 0xFF };
-UBYTE kernel_command_line[256] = { 0x00, 0xFF }; /* special none value */
+struct _KernelConfig InitKernelConfig = { -1 };
+char kernel_command_line[256] = { 0, -1 }; /* special none value */
 int kernel_command_line_length BSS_INIT(0);
 UBYTE debugger_present = 0xFF;	/* initialised in kernel.asm
 				   do NOT set 0 here or compiler may
@@ -111,7 +111,7 @@ VOID ASMCFUNC FreeDOSmain(void)
 
 #ifdef DEBUG
   /* printf must go after setup_int_vectors call */
-  if (kernel_command_line[0] == 0x00 && kernel_command_line[1] == 0xFF) {
+  if (kernel_command_line[0] == 0 && kernel_command_line[1] == (char)-1) {
     printf("\nKERNEL: Command line is not specified.\n");
   } else {
     printf("\nKERNEL: Command line is \"%s\"\n", kernel_command_line);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -44,8 +44,6 @@ static char copyright[] =
     "GNU General Public License as published by the Free Software Foundation;\n"
     "either version 2, or (at your option) any later version.\n";
 
-struct _KernelConfig InitKernelConfig BSS_INIT({0});
-
 STATIC VOID InitIO(void);
 
 STATIC VOID update_dcb(struct dhdr FAR *);
@@ -70,6 +68,8 @@ __segment DosTextSeg = 0;
 
 struct lol FAR *LoL = &DATASTART;
 
+struct _KernelConfig InitKernelConfig = { 0xFF };
+
 VOID ASMCFUNC FreeDOSmain(void)
 {
   unsigned char drv;
@@ -92,17 +92,8 @@ VOID ASMCFUNC FreeDOSmain(void)
 
   drv = LoL->BootDrive + 1;
   p = MK_FP(0, 0x5e0);
-  if (fmemcmp(p+2,"CONFIG",6) == 0)      /* UPX */
   {
-    fmemcpy(&InitKernelConfig, p+2, sizeof(InitKernelConfig));
-
-    drv = *p + 1;
-    *(DWORD FAR *)(p+2) = 0;
-  }
-  else
-  {
-    *p = drv - 1;
-    fmemcpy(&InitKernelConfig, &LowKernelConfig, sizeof(InitKernelConfig));
+    *p = drv - 1;	/* compatibility with older kernels */
   }
 
   if (drv >= 0x80)

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -270,7 +270,7 @@ STATIC void setup_int_vectors(void)
 
   /* install default handlers */
   for (i = 0x23; i <= 0x3f; i++)
-    setvec(i, empty_handler);
+    setvec(i, empty_handler); /* note: int 31h segment should be DOS DS */
   HaltCpuWhileIdle = 0;
   for (pvec = vectors; pvec < vectors + (sizeof vectors/sizeof *pvec); pvec++)
     setvec(pvec->intno, (intvec)MK_FP(FP_SEG(empty_handler), pvec->handleroff));

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -844,6 +844,8 @@ COUNT DosExec(COUNT mode, exec_blk FAR * ep, BYTE FAR * lp)
   else if (rc != 0)
   {
     rc = DosComLoader(lp, &TempExeBlock, mode, fd);
+  } else {
+    rc = DE_INVLDFMT;
   }
 
   DosCloseSft(fd, FALSE);

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -72,7 +72,7 @@ INITPATCH=ia16-elf-objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sy
 CLDEF=1
 CLT=gcc -DDOSC_TIME_H -I../hdr -o $@
 CLC=$(CLT)
-LINK=$(XLINK) -Tkernel.ld -Wl,-Map,kernel.map -o kernel.exe $(OBJS) -Wl,--whole-archive ../drivers/device.lib -Wl,--no-whole-archive \#
+LINK=$(XLINK) -Tkernel.ld -nostdlib -Wl,-Map,kernel.map -o kernel.exe $(OBJS) -Wl,--whole-archive ../drivers/device.lib -Wl,--no-whole-archive \#
 
 .SUFFIXES: .obj .asm
 

--- a/sys/fdkrncfg.c
+++ b/sys/fdkrncfg.c
@@ -161,7 +161,7 @@ void displayConfigSettings(KernelConfig * cfg)
   /* print known options and current value - only if available */
 
   /* show kernel version if available, read only, no option to modify */
-  if (cfg->ConfigSize >= 20)
+  if (cfg->ConfigSize >= 12)
   {
     printf
         ("%s kernel %s (build %d.%d OEM:%02X)\n", 

--- a/sys/fdkrncfg.c
+++ b/sys/fdkrncfg.c
@@ -13,7 +13,7 @@
 *  merged into SYS by tom ehlert                                                                        *
 ***************************************************************************/
 
-char VERSION[] = "v1.02";
+char VERSION[] = "v1.03";
 char PROGRAM[] = "SYS CONFIG";
 char KERNEL[] = "KERNEL.SYS";
 
@@ -93,7 +93,8 @@ void showUsage(void)
   printf("  Current Options are: DLASORT=0|1, SHOWDRIVEASSIGNMENT=0|1\n"
          "                       SKIPCONFIGSECONDS=#, FORCELBA=0|1\n"
          "                       GLOBALENABLELBASUPPORT=0|1\n"
-         "                       BootHarddiskSeconds=0|seconds to wait\n");
+         "                       BootHarddiskSeconds=0|seconds to wait\n"
+         "                       CheckDebugger=0|1|2\n");
 }
 
 /* simply reads in current configuration values, exiting program
@@ -213,6 +214,13 @@ void displayConfigSettings(KernelConfig * cfg)
     printf
         ("BootHarddiskSeconds=%d :      *0=no else seconds to wait for key\n",
          cfg->BootHarddiskSeconds);
+  }
+
+  if (cfg->ConfigSize >= 13)
+  {
+    printf
+        ("CheckDebugger=%d :            *0=no, 1=check, 2=assume\n",
+         cfg->CheckDebugger);
   }
 
 #if 0                           /* we assume that SYS is as current as the kernel */
@@ -481,6 +489,11 @@ int FDKrnConfigMain(int argc, char **argv)
     {
       setSByteOption(&(cfg.BootHarddiskSeconds),
                      cptr, 0, 127, &updates, "BootHarddiskSeconds");
+    }
+    else if (memicmp(argptr, "CheckDebugger", 5) == 0)
+    {
+      setByteOption(&(cfg.CheckDebugger),
+                     cptr, 2, &updates, "CheckDebugger");
     }
     else
     {

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -375,25 +375,28 @@ static void write_trailer(FILE *dest, size_t size, int compress_sys_file,
     0xAA,                     /* 15 stosb (store drive number)*/
     0x8B, 0xF7,               /* 16 mov si,di                 */
     0xF3, 0xA4,               /* 18 rep movsb                 */
-    0x1E,                     /* 20 push ds                   */
-    0x58,                     /* 21 pop  ax                   */
-    0x05, 0x00, 0x00,         /* 22 add ax,...                */
-    0x8E, 0xD0,               /* 25 mov ss,ax                 */
-    0xBC, 0x00, 0x00,         /* 27 mov sp,...                */
-    0x31, 0xC0,               /* 30 xor ax,ax                 */
-    0xFF, 0xE0                /* 32 jmp ax                    */
+0x55,				/* 20 push bp */
+0x26, 0x8C, 0x16, 0x1E, 0x00,	/* 21 mov word [es:(#32 - 2)], ss */
+0x26, 0x89, 0x26, 0x1C, 0x00,	/* 26 mov word [es:(#32 - 4)], sp */
+    0x1E,                     /* 31 push ds                   */
+    0x58,                     /* 32 pop  ax                   */
+    0x05, 0x00, 0x00,         /* 33 add ax,...                */
+    0x8E, 0xD0,               /* 36 mov ss,ax                 */
+    0xBC, 0x00, 0x00,         /* 38 mov sp,...                */
+    0x31, 0xC0,               /* 41 xor ax,ax                 */
+    0xFF, 0xE0                /* 43 jmp ax                    */
   };
 
   *(short *)&trailer[1] = (short)size + 0x20;
-  *(short *)&trailer[23] = header->exInitSS;
-  *(short *)&trailer[28] = header->exInitSP;
+  *(short *)&trailer[34] = header->exInitSS;
+  *(short *)&trailer[39] = header->exInitSP;
   if (compress_sys_file) {
     /* replace by jmp word ptr [6]: ff 26 06 00
        (the .SYS strategy handler which will unpack) */
-    *(long *)&trailer[30] = 0x000626ffL;
+    *(long *)&trailer[41] = 0x000626ffL;
     /* set up a 4K stack for the UPX decompressor to work with */
-    *(short *)&trailer[23] = 0x1000;
-    *(short *)&trailer[28] = 0x1000;
+    *(short *)&trailer[34] = 0x1000;
+    *(short *)&trailer[39] = 0x1000;
   }
   fwrite(trailer, 1, sizeof trailer, dest);
 }


### PR DESCRIPTION
The kernel command line can be set by bootable lDebug using a command like the following to load the kernel: `boot protocol=freedos cmdline=1 kernel.sys // config=testconf.sys`

I submitted [a pull request to dosemu2](https://github.com/dosemu2/dosemu2/pull/1635) to add support for setting the RxDOS/FreeDOS kernel command line but it was rejected.