### PR TITLE
ecm 2022-05 optimise entry

### DIFF
--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -317,6 +317,7 @@ extern struct RelocationTable DOSFAR ASM _HMARelocationTableStart[];
 extern struct RelocationTable DOSFAR ASM _HMARelocationTableEnd[];
 
 extern void FAR *DOSFAR ASM XMSDriverAddress;
+extern UBYTE DOSFAR ASM XMS_Enable_Patch;
 #ifdef __GNUC__
 extern VOID ASMPASCAL _EnableA20(VOID) FAR;
 extern VOID ASMPASCAL _DisableA20(VOID) FAR;

--- a/kernel/inithma.c
+++ b/kernel/inithma.c
@@ -179,6 +179,7 @@ int MoveKernelToHMA()
     return FALSE;
 
   XMSDriverAddress = xms_addr;
+  XMS_Enable_Patch = 0x90;	/* must be set after XMSDriverAddress */
 
 #ifdef DEBUG
   /* A) for debugging purpose, suppress this, 


### PR DESCRIPTION
Some assembly tricks:

* SMC instead of checking the XMS driver address
in the DOS DS stub,

* SMC so that the address goes right into a
`call far immediate` instruction,

* use `repe cmpsw` to compare multiple words (saves
space over the individual word compares),

* near calls to far functions use push cs to build
a far-call stack frame,

* segments 0 and FFFFh generated by segment arithmetic
instead of loading from memory,

* common case (A20 already enabled) made to be the case
where the conditional branch just falls through, which
may be slightly better.