### PR TITLE
ecm new exeflat format

### DIFF
--- a/kernel/makefile
+++ b/kernel/makefile
@@ -36,8 +36,8 @@ production:     ../bin/$(TARGET).sys ../bin/country.sys
 
 # -S to avoid showing expected relocations
 # 0x10 & 0x78 or 0x79 depending on compilation options
-kernel.sys:	kernel.exe ../utils/exeflat.exe ../utils/upxentry.bin
-		..$(DIRSEP)utils$(DIRSEP)exeflat.exe kernel.exe kernel.sys $(LOADSEG) -S0x10 -S0x78 -S0x79 -E..$(DIRSEP)utils$(DIRSEP)upxentry.bin $(UPXOPT) $(XUPX)
+kernel.sys:	kernel.exe ../utils/exeflat.exe ../utils/upxentry.bin ../utils/upxdevic.bin
+		..$(DIRSEP)utils$(DIRSEP)exeflat.exe kernel.exe kernel.sys $(LOADSEG) -S0x10 -S0x78 -S0x79 -E..$(DIRSEP)utils$(DIRSEP)upxentry.bin -D..$(DIRSEP)utils$(DIRSEP)upxdevic.bin $(UPXOPT) $(XUPX)
 
 kernel.exe:	$(TARGET).lnk $(OBJS) $(LIBS)
 		$(LINK) @$(TARGET).lnk;

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -36,8 +36,8 @@ production:     ../bin/$(TARGET).sys ../bin/country.sys
 
 # -S to avoid showing expected relocations
 # 0x10 & 0x78 or 0x79 depending on compilation options
-kernel.sys:	kernel.exe ../utils/exeflat.exe
-		..$(DIRSEP)utils$(DIRSEP)exeflat.exe kernel.exe kernel.sys $(LOADSEG) -S0x10 -S0x78 -S0x79 $(UPXOPT) $(XUPX)
+kernel.sys:	kernel.exe ../utils/exeflat.exe ../utils/upxentry.bin
+		..$(DIRSEP)utils$(DIRSEP)exeflat.exe kernel.exe kernel.sys $(LOADSEG) -S0x10 -S0x78 -S0x79 -E..$(DIRSEP)utils$(DIRSEP)upxentry.bin $(UPXOPT) $(XUPX)
 
 kernel.exe:	$(TARGET).lnk $(OBJS) $(LIBS)
 		$(LINK) @$(TARGET).lnk;

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -81,9 +81,10 @@ static int compReloc(const void *p1, const void *p2)
 static void usage(void)
 {
   printf("usage: exeflat (src.exe) (dest.sys) (relocation-factor)\n");
-  printf
-      ("               -S10   - Silent relocate segment 10 (down list)\n");
-  
+  printf("               -S10   - Silent relocate segment 10 (down list)\n");
+  printf("               -E(path/to/upxentry.bin)   - Omit to force DOS/SYS compression\n");
+  printf("               -D(path/to/upxdevic.bin)   - Omit to force DOS/EXE compression\n");
+  printf("               -U (command) (parameters)  - Specify to use UPX compression\n");
   exit(1);
 }
 

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -102,7 +102,7 @@ static int exeflat(const char *srcfile, const char *dstfile,
   UWORD curbufoffset;
   FILE *src, *dest;
   short silentdone = 0;
-  int compress_sys_file;
+  int compress_sys_file = 0;
   UWORD stubsize = 0;
 
   if ((src = fopen(srcfile, "rb")) == NULL)
@@ -221,9 +221,18 @@ static int exeflat(const char *srcfile, const char *dstfile,
   }
 
   /* The biggest .sys file that UPX accepts seems to be 65419 bytes long */
-  compress_sys_file = (size - (0x20 - 0x10)) < 65420;
   if (UPX) {
-      printf("Compressing kernel - %s format\n", (compress_sys_file)?"sys":"exe");
+    if (stubdevsize && stubexesize)
+      compress_sys_file = (size - (0x20 - 0x10)) < 65420;
+    else if (stubexesize)
+      compress_sys_file = 0;
+    else if (stubdevsize)
+      compress_sys_file = 1;
+    else {
+      printf("Error: Entry file must be specified\n");
+      exit(1);
+    }
+    printf("Compressing kernel - %s format\n", (compress_sys_file)?"sys":"exe");
    if (!compress_sys_file) {
     stubsize = stubexesize;
     ULONG realsize;

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -220,10 +220,17 @@ static int exeflat(const char *srcfile, const char *dstfile,
     exit(1);
   }
 
-  /* The biggest .sys file that UPX accepts seems to be 65419 bytes long */
+  /* The biggest .sys file that UPX accepts seems to be 65419 bytes long.
+	Actually, UPX 3.96 appears to accept DOS/SYS files up to 65426 bytes.
+	To avoid problems we use a slightly lower limit. */
   if (UPX) {
     if (stubdevsize && stubexesize)
-      compress_sys_file = (size - (0x20 - 0x10)) < 65420;
+      compress_sys_file = (size - stubdevsize) <= /* 65426 */ 65400;
+	/* would need to subtract 0x10 for the device header here
+		but then add in the same, because we skip 0x10 bytes
+		of the source file but fill the same length with the
+		doctored device header. so (size - stubdevsize) gives
+		the exact result that we want to compare against. */
     else if (stubexesize)
       compress_sys_file = 0;
     else if (stubdevsize)

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -545,6 +545,7 @@ int main(int argc, char **argv)
   memcpy(cmdbuf + len, tmpexe, len2);
   cmdbuf[len + len2] = '\0';
   printf("%s\n", cmdbuf);
+  fflush(stdout);
   if (system(cmdbuf))
   {
     printf("Problems executing %s\n", cmdbuf);

--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -577,9 +577,9 @@ int main(int argc, char **argv)
     rename("tmp.sys", "tmp.bin");
   }
 
-  /* argv[2] now contains the final flattened file: just
-     header and trailer need to be added */
-  /* the compressed file has two chunks max */
+  /* tmp.bin now contains the final flattened file: just
+     the UPX entry header needs to be added. */
+  /* the compressed file may exceed 64 KiB for DOS/EXE format. */
 
   if ((dest = fopen(argv[2], "wb")) == NULL)
   {

--- a/utils/makefile
+++ b/utils/makefile
@@ -2,13 +2,16 @@
 
 CFLAGS = -I..$(DIRSEP)hdr
 
-production: patchobj.com exeflat.exe upxentry.bin
+production: patchobj.com exeflat.exe upxentry.bin upxdevic.bin
 
 patchobj.com: patchobj.c
 	$(CLT) $(CFLAGS) patchobj.c
 
 upxentry.bin: upxentry.asm
 	$(NASM) -f bin upxentry.asm -o upxentry.bin
+
+upxdevic.bin: upxdevic.asm
+	$(NASM) -f bin upxdevic.asm -o upxdevic.bin
 
 exeflat.exe: exeflat.c ../hdr/exe.h
 	$(CLC) $(CFLAGS) exeflat.c
@@ -18,5 +21,5 @@ clobber: clean
 
 clean:
 	$(RM) *.obj *.bak *.crf *.xrf *.map *.lst *.las *.cod *.err status.me
-	$(RM) exeflat.exe patchobj.com upxentry.bin
+	$(RM) exeflat.exe patchobj.com upxentry.bin upxdevic.bin
 

--- a/utils/makefile
+++ b/utils/makefile
@@ -2,10 +2,13 @@
 
 CFLAGS = -I..$(DIRSEP)hdr
 
-production: patchobj.com exeflat.exe
+production: patchobj.com exeflat.exe upxentry.bin
 
 patchobj.com: patchobj.c
 	$(CLT) $(CFLAGS) patchobj.c
+
+upxentry.bin: upxentry.asm
+	$(NASM) -f bin upxentry.asm -o upxentry.bin
 
 exeflat.exe: exeflat.c ../hdr/exe.h
 	$(CLC) $(CFLAGS) exeflat.c
@@ -15,5 +18,5 @@ clobber: clean
 
 clean:
 	$(RM) *.obj *.bak *.crf *.xrf *.map *.lst *.las *.cod *.err status.me
-	$(RM) exeflat.exe patchobj.com
+	$(RM) exeflat.exe patchobj.com upxentry.bin
 

--- a/utils/upxdevic.asm
+++ b/utils/upxdevic.asm
@@ -1,0 +1,37 @@
+	cpu 8086
+	org 0
+
+bootloadunit:		; (byte of short jump re-used)
+start:
+	jmp strict short entry
+	times (32 - 4) - ($ - $$) db 0
+			; area for CONFIG block
+
+bootloadstack:		; (dword re-used for original ss:sp)
+entry:
+		; common setup (copied from kernel.asm)
+	push cs
+	pop ds
+	xor di, di
+	mov byte [di + bootloadunit - $$], bl
+	push bp
+	mov word [di + bootloadstack - $$], sp
+	mov word [di + bootloadstack + 2 - $$], ss
+
+		; the UPX DOS/SYS depacker does not need a certain ss:sp
+		;  however it appears to need cs == ds
+
+	mov ds, word [di + patchcsip + 2 - $$]
+	jmp 0:0
+patchcsip:		equ $ - 4
+end:
+
+	times 0C0h - ($ - $$) nop
+entry_common:
+
+	times 100h - ($ - $$) db 0
+	dw 0
+	dw 0
+	dw 0
+	dw patchcsip
+	dw end

--- a/utils/upxdevic.asm
+++ b/utils/upxdevic.asm
@@ -1,3 +1,11 @@
+
+%if 0
+
+UPX preparation stub for DOS/SYS format compressed FreeDOS kernel
+ Public Domain by C. Masloch, 2022
+
+%endif
+
 	cpu 8086
 	org 0
 

--- a/utils/upxentry.asm
+++ b/utils/upxentry.asm
@@ -1,3 +1,11 @@
+
+%if 0
+
+UPX preparation stub for DOS/EXE format compressed FreeDOS kernel
+ Public Domain by C. Masloch, 2022
+
+%endif
+
 	cpu 8086
 	org 0
 

--- a/utils/upxentry.asm
+++ b/utils/upxentry.asm
@@ -1,0 +1,47 @@
+	cpu 8086
+	org 0
+
+bootloadunit:		; (byte of short jump re-used)
+start:
+	jmp strict short entry
+	times (32 - 4) - ($ - $$) db 0
+			; area for CONFIG block
+
+bootloadstack:		; (dword re-used for original ss:sp)
+entry:
+		; common setup (copied from kernel.asm)
+	push cs
+	pop ds
+	xor di, di
+	mov byte [di + bootloadunit - $$], bl
+	push bp
+	mov word [di + bootloadstack - $$], sp
+	mov word [di + bootloadstack + 2 - $$], ss
+
+		; the UPX DOS/EXE depacker needs a certain ss:sp
+	cli
+	mov ax, 0
+patchstacksegment:	equ $ - 2
+	mov ss, ax
+	mov sp, 0
+patchstackpointer:	equ $ - 2
+	sti
+
+	mov ax, -10h
+patchpspsegment:	equ $ - 2
+	mov ds, ax
+	mov es, ax
+
+	jmp 0:0
+patchcsip:		equ $ - 4
+end:
+
+	times 0C0h - ($ - $$) nop
+entry_common:
+
+	times 100h - ($ - $$) db 0
+	dw patchstackpointer
+	dw patchstacksegment
+	dw patchpspsegment
+	dw patchcsip
+	dw end


### PR DESCRIPTION
Copying the commit message of the first commit in this PR:

This format has several advantages:

* The CONFIG block need not be moved.

* The entire compressed image (depacker and payload) need not be moved another time before the UPX depacker's own operation.

* The CONFIG block always lives at 00602h, and the kernel need not be aware whether it was compressed for detecting which CONFIG block to use.

* Support for compressed images beyond 64 KiB for free. (The assembly define TEST_FILL_INIT_TEXT can be passed in NASMENV to test this support with 32 KiB of LFSR output.)

* A subsequent commit will shorten the stub to 64 bytes, compared to the prior 32 + 45 = 77 bytes, with no loss of features. (The packed payload is a bit shorter too.) (PR: This commit is included in the PR.)

* The new stub also sets ds and es to the segment value that would point to the DOS/EXE process's PSP. This is apparently not used by the UPX depacker but could be in a future or past version, or if another packer is used.

Additional PR comments: There are more commits that add DOS/SYS format compression, as well as the ability to force DOS/SYS or DOS/EXE format compression by omitting the other format's entry file switch to exeflat. The new entry header stub can be assembled into anything between 32 and 192 bytes, exeflat need not be modified to allow longer entry files (up to 192 bytes).