### PR TITLE
FCB (int 21h func 29h): should keep parsing name even if drive letter invalid

### DIFF
--- a/kernel/fcbfns.c
+++ b/kernel/fcbfns.c
@@ -90,7 +90,7 @@ BYTE FAR *FatGetDrvData(UBYTE drive, UBYTE * pspc, UWORD * bps, UWORD * nc)
 #ifndef IPL
 UWORD FcbParseFname(UBYTE *wTestMode, const BYTE FAR * lpFileName, fcb FAR * lpFcb)
 {
-  WORD wRetCodeName = FALSE, wRetCodeExt = FALSE;
+  WORD wRetCodeDrive = FALSE, wRetCodeName = FALSE, wRetCodeExt = FALSE;
 
   /* pjv -- ExtFcbToFcb?                                          */
   
@@ -105,18 +105,18 @@ UWORD FcbParseFname(UBYTE *wTestMode, const BYTE FAR * lpFileName, fcb FAR * lpF
   lpFileName = ParseSkipWh(lpFileName);
 
   /* Now check for drive specification                            */
-  /* If drive specified, set to it (when valid) otherwise         */
+  /* If drive specified, set to it otherwise                      */
   /* set to default drive unless leave as-is requested            */
+
+  /* Undocumented behavior: should keep parsing even if drive     */
+  /* specification is invalid  -- tkchia 20220715                 */
   if (*(lpFileName + 1) == ':')
   {
     /* non-portable construct to be changed                 */
     REG UBYTE Drive = DosUpFChar(*lpFileName) - 'A';
 
     if (get_cds(Drive) == NULL)
-    {
-      *wTestMode = PARSE_RET_BADDRIVE;
-      return FP_OFF(lpFileName);
-    }
+      wRetCodeDrive = TRUE;
 
     lpFcb->fcb_drive = Drive + 1;
     lpFileName += 2;
@@ -163,7 +163,12 @@ UWORD FcbParseFname(UBYTE *wTestMode, const BYTE FAR * lpFileName, fcb FAR * lpF
         GetNameField(++lpFileName, (BYTE FAR *) lpFcb->fcb_fext,
                      FEXT_SIZE, (BOOL *) & wRetCodeExt);
 
-  *wTestMode = (wRetCodeName | wRetCodeExt) ? PARSE_RET_WILD : PARSE_RET_NOWILD;
+  if (wRetCodeDrive)
+    *wTestMode = PARSE_RET_BADDRIVE;
+  else if (wRetCodeName | wRetCodeExt)
+    *wTestMode = PARSE_RET_WILD;
+  else
+    *wTestMode = PARSE_RET_NOWILD;
   return FP_OFF(lpFileName);
 }
 


### PR DESCRIPTION
On both MS-DOS 2.11 and MS-DOS 5.0, the "parse filename to FCB" syscall (`int 0x21`, function `0x29`), when it encounters an invalid drive letter, will still continue parsing the file name, and return with `al` = `0xff` _and_ `ds:si` pointing after the parsed file name.

E.g. given an input like `z:foo.bar,baz` &mdash; assuming `z` is not a valid drive letter &mdash; the syscall will return `al` = `0xff` and `ds:si` pointing at the comma.

This patch modifies the FreeDOS kernel to follow the same behaviour.

Thank you!