### PR TITLE
FCB (int 21h func 29h): should not accept field separator as "drive letter"

### DIFF
--- a/kernel/fcbfns.c
+++ b/kernel/fcbfns.c
@@ -110,7 +110,9 @@ UWORD FcbParseFname(UBYTE *wTestMode, const BYTE FAR * lpFileName, fcb FAR * lpF
 
   /* Undocumented behavior: should keep parsing even if drive     */
   /* specification is invalid  -- tkchia 20220715                 */
-  if (*(lpFileName + 1) == ':')
+  /* drive specification can refer to an invalid drive, but must  */
+  /* not itself be a file name delimiter!  -- tkchia 20220716     */
+  if (!TestFieldSeps(lpFileName) && *(lpFileName + 1) == ':')
   {
     /* non-portable construct to be changed                 */
     REG UBYTE Drive = DosUpFChar(*lpFileName) - 'A';


### PR DESCRIPTION
This is a follow-up to my earlier pull request at https://github.com/FDOS/kernel/pull/82 .

In the earlier patch, I modified the "parse filename to FCB" syscall (`int 0x21`, function `0x29`) so that, even if it encounters an invalid drive letter, it will still continue parsing the file name after the drive letter.

However, I forgot to add a needed check: the "drive letter" can be invalid, but must not be a file name delimiter (e.g. a control character).  E.g. given an input like `\r:foo.bar,baz` &mdash; where `\r` is the carriage return character &mdash; the syscall should stop immediately at the `\r`, and not try to parse beyond it.

This new pull request adds this check.

Thank you!