### PR TITLE
ecm sys fix

### DIFF
--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1448,9 +1448,7 @@ void dumpBS(const char *bsFile, int drive)
 
 void put_boot(SYSOptions *opts)
 {
-#ifdef WITHFAT32
   struct bootsectortype32 *bs32;
-#endif
   struct bootsectortype *bs;
   UBYTE oldboot[SEC_SIZE], newboot[SEC_SIZE];
   UBYTE default_bpb[0x5c];

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -121,8 +121,8 @@ struct _diskfree_t {
 int int86(int ivec, union REGS *in, union REGS *out)
 {
   /* must save sp for int25/26 */
-  asm("mov %5, (1f+1); jmp 0f; 0:mov %%di, %%dx; mov %%sp, %%di;"
-      "1:int $0x00; mov %%di, %%sp; sbb %0, %0" :
+  asm("mov %5, (1f+1); jmp 0f; 0:push %%ds; mov %%di, %%dx; mov %%sp, %%di;"
+      "1:int $0x00; mov %%di, %%sp; pop %%ds; sbb %0, %0" :
       "=r"(out->x.cflag),
       "=a"(out->x.ax), "=b"(out->x.bx), "=c"(out->x.cx), "=d"(out->x.dx) :
       "q"((unsigned char)ivec), "a"(in->x.ax), "b"(in->x.bx),


### PR DESCRIPTION
Fix two bugs in SYS: The int86 for gcc should preserve ds, and not defining WITHFAT32 should still allow to build SYS.

The former caused seemingly random crashes and impacted even a debugger trying to examine the program, as it lead to the code corrupting data in the DOS data segment.

The latter was a minor issue leading to build failure.