### PR TITLE
fatfs.c: allow bpbSectorsPerCluster == 0 to mean 256

### DIFF
--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -363,7 +363,9 @@ load_next:      dec     ax                      ; cluster numbers start with 2
                 dec     ax
 
                 mov     di, word [bsSecPerClust]
-                and     di, 0xff                ; DI = sectors per cluster
+                dec     di                      ; minus one if 256 spc
+                and     di, 0xff                ; DI = sectors per cluster - 1
+                inc     di                      ; = spc
                 mul     di
                 add     ax, [data_start]
                 adc     dx, [data_start+2]      ; DX:AX = first sector to read
@@ -422,9 +424,9 @@ read_next:
 
                 ; NOTE: sys must be updated if location changes!!!
 %ifdef ISFAT12
-  %define LBA_TEST_OFFSET 179h
+  %define LBA_TEST_OFFSET 17Bh
 %elifdef ISFAT16
-  %define LBA_TEST_OFFSET 176h
+  %define LBA_TEST_OFFSET 178h
 %else
   %define LBA_TEST_OFFSET 0
                 ; Just a placeholder, so the proper error message

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -294,7 +294,9 @@ c3:
                 sub     ax, 2
                 sbb     cx, byte 0           ; CX:AX == cluster - 2
                 mov     bl, [bsSecPerClust]
-                sub     bh, bh
+                dec     bx              ; bl = spc - 1, 0FFh if 256 spc
+                sub     bh, bh          ; bx = spc - 1
+                inc     bx              ; bx = spc
                 xchg    cx, ax          ; AX:CX == cluster - 2
                 mul     bx              ; first handle high word
                                         ; DX must be 0 here

--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -313,6 +313,8 @@ convert_cluster:
 		dec	eax
 
 		movzx	edx, byte [bsSecPerClust]
+                dec     dl              ; spc - 1
+                inc     dx              ; spc
 		push	edx
 		mul	edx
 		pop	edx

--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1584,13 +1584,17 @@ VOID bpb_to_dpb(bpb FAR * bpbp, REG struct dpb FAR * dpbp)
   bpb sbpb;
 
   fmemcpy(&sbpb, bpbp, sizeof(sbpb));
-  for (shftcnt = 0; (sbpb.bpb_nsector >> shftcnt) > 1; shftcnt++)
-    ;
+  if (sbpb.bpb_nsector == 0) {
+    shftcnt = 8;
+  } else {
+    for (shftcnt = 0; (sbpb.bpb_nsector >> shftcnt) > 1; shftcnt++)
+      ;
+  }
   dpbp->dpb_shftcnt = shftcnt;
 
   dpbp->dpb_mdb = sbpb.bpb_mdesc;
   dpbp->dpb_secsize = sbpb.bpb_nbyte;
-  dpbp->dpb_clsmask = sbpb.bpb_nsector - 1;
+  dpbp->dpb_clsmask = (sbpb.bpb_nsector - 1) & 0xFF;
   dpbp->dpb_fatstrt = sbpb.bpb_nreserved;
   dpbp->dpb_fats = sbpb.bpb_nfat;
   dpbp->dpb_dirents = sbpb.bpb_ndirent;

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1567,7 +1567,7 @@ void put_boot(SYSOptions *opts)
       /* !!! if boot sector changes then update these locations !!! */
       {
           unsigned offset;
-          offset = (fs == FAT16) ? 0x176 : 0x179;
+          offset = (fs == FAT16) ? 0x178 : 0x17B;
           
           if ( (newboot[offset]==0x84) && (newboot[offset+1]==0xD2) ) /* test dl,dl */
           {


### PR DESCRIPTION
This should be compatible to Enhanced DR-DOS.

Tested by building a boot image like the following:

nasm ../ldosmbr/oldmbr.asm -o oldmbr.bin
nasm ../ldosboot/boot.asm -D_FAT16=1 -I ../lmacros/ \
 -D_LOAD_NAME="'LDEBUG'" -o boot16.bin
nasm bootimg.asm -I ../lmacros/ -o disk16.img \
 -D_MBR -D_ALIGNDATA -D_BOOTPATCHFILE=boot16.bin \
 -D_MBRPATCHFILE=oldmbr.bin -D_BPE=16 \
 -D_SPI='(_SPC * 5000)' -D_NUMROOT=512 -D_SPC=256 \
 -D_SPF='((_SPI / _SPC + 255) / 256)' \
 -D_PAYLOADFILE=../ldebug/bin/ldebug.com,quit.com,\
::rename,../k256spc/bin/kernel.sys,kernel.sys,\
command.com,::fill,1,32,autoexec.bat

The repos bootimg, ldosboot, ldosmbr, and lmacros are available at https://hg.pushbx.org/ecm/

The file ldebug.com is a recent bootable lDebug debugger. The file command.com is a recent FreeCOM. The file quit.com is assembled with NASM from
https://hg.pushbx.org/ecm/ldebug/file/e6035c05670a/misc/quit.asm

Run like this:

qemu-system-i386 -hda disk16.img -boot order=c -display curses

To the lDebug prompt "-" enter "boot protocol freedos", then a "q" command. On success, the quit.com command can be run to quit the qemu VM.

Not yet done:

- initdisk.c:512 uses MAXCLUSTSIZE defined to 128. This is not difficult to change but it is unclear whether this should be changed.

- The boot loaders are not yet adjuscted, requiring use of the ldosboot or lDebug loaders instead.

- A patch for FORMAT (copylefted) version 0.91u is available from the Enhanced DR-DOS project. Mirrored in the directory at https://pushbx.org/ecm/download/edrdos/freedos/
This should be easy enough to update to the most recent version.