### PR TITLE
ecm sys fs fix

### DIFF
--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1506,7 +1506,7 @@ void put_boot(SYSOptions *opts)
     totalSectors = bs32->bsSectors ? bs32->bsSectors : bs32->bsHugeSectors;
     dataSectors = totalSectors
       - bs32->bsResSectors - (bs32->bsFATs * fatSize) - rootDirSectors;
-    clusters = dataSectors / bs32->bsSecPerClust;
+    clusters = dataSectors / (((bs32->bsSecPerClust - 1) & 0xFF) + 1);
  
     if (clusters < FAT_MAGIC)        /* < 4085 */
       fs = FAT12;


### PR DESCRIPTION
Fixes https://github.com/FDOS/kernel/issues/93 and also completes https://github.com/FDOS/kernel/pull/95 (SYS was overlooked because of using a different field name for the SPC entry of the BPB.)