### PR TITLE
inthndlr: align hma size to para

### DIFF
--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1925,6 +1925,7 @@ VOID ASMCFUNC int2F_12_handler(struct int2f12regs FAR *pr)
 {
   COUNT rc;
   long lrc;
+  UDWORD tsize;
 
 #define r (*pr)
 
@@ -1939,8 +1940,9 @@ VOID ASMCFUNC int2F_12_handler(struct int2f12regs FAR *pr)
       size = ~offs;                        /* BX for query HMA   */
       if (r.AL == 0x02)                    /* allocate HMA space */
       {
-        if (r.BX < size)
-          size = r.BX;
+        tsize = (r.BX + 0xf) & 0xfffffff0; /* align to paragraph */
+        if (tsize < size)
+          size = (UWORD)tsize;
         AllocateHMASpace(offs, offs+size);
         firstAvailableBuf += size;
       }


### PR DESCRIPTION
Based on a patch https://github.com/dosemu2/fdpp/commit/e7fe81d458 for FDDP by @stsp

[fixes #101]