### PR TITLE
ecm fdconfig env

### DIFF
--- a/kernel/asmsupt.asm
+++ b/kernel/asmsupt.asm
@@ -286,7 +286,6 @@ pascal_return:
                 
 ; fstrcpy (void FAR*dest, void FAR *src);
 
-%ifndef _INIT
                 global  FSTRCPY
 FSTRCPY:
                 call pascal_setup
@@ -301,7 +300,6 @@ arg {dest,4}, {src,4}
 		mov   bl,8
                 
                 jmp short dostrcpy
-%endif
 
 ;******
                 global  STRCPY
@@ -570,10 +568,6 @@ strncmp_retzero:
 strncmp_done:
                 lahf
 		ror  ah,1
-%ifdef _INIT
-strncmp_done2:  jmp  short pascal_return
-%else
 strncmp_done2:  jmp  pascal_return
-%endif
 
 %endif

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -127,8 +127,7 @@ size_t ebda_size BSS_INIT(0);
 
 static UBYTE ErrorAlreadyPrinted[128] BSS_INIT({0});
 
-char master_env[128] BSS_INIT({0});
-static char *envp = master_env;
+static char FAR *envp = master_env;
 
 struct config Config = {
   0,
@@ -2416,8 +2415,15 @@ RestartInput:
   printf("\n");
 
   /* export the current selected config  menu */
-  sprintf(envp, "CONFIG=%c", MenuSelected+'0');
-  envp += 9;
+  {
+    char buffer[10];
+    int len;
+    sprintf(buffer, "CONFIG=%c", MenuSelected+'0');
+    len = strlen(buffer);
+    fstrcpy(envp, buffer);
+    envp += len + 1;
+    *envp = 0;
+  }
   if (MenuColor != -1)
     ClearScreen(0x7);
 }
@@ -2745,8 +2751,9 @@ STATIC VOID CmdSet(BYTE *pLine)
     size = strlen(szBuf);
     if (size < master_env + sizeof(master_env) - envp - 1)
     {                     /* must end with two consequtive zeros */
-      strcpy(envp, szBuf);
+      fstrcpy(envp, szBuf);
       envp += size + 1;   /* add next variables starting at the second zero */
+      *envp = 0;
     }
     else
       printf("Master environment is full - can't add \"%s\"\n", szBuf);

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -2423,6 +2423,8 @@ RestartInput:
     fstrcpy(envp, buffer);
     envp += len + 1;
     *envp = 0;
+    envp[1] = 0;
+    envp[2] = 0;
   }
   if (MenuColor != -1)
     ClearScreen(0x7);
@@ -2749,11 +2751,15 @@ STATIC VOID CmdSet(BYTE *pLine)
     pLine = skipwh(++pLine);
     strcat(szBuf, pLine); /* append the variable value (may include spaces) */
     size = strlen(szBuf);
-    if (size < master_env + sizeof(master_env) - envp - 1)
+    if (size < master_env + sizeof(master_env) - envp - 1 - 2)
     {                     /* must end with two consequtive zeros */
       fstrcpy(envp, szBuf);
       envp += size + 1;   /* add next variables starting at the second zero */
       *envp = 0;
+      envp[1] = 0;
+      envp[2] = 0;
+      /* The word marker after last variable should not equal 1,
+          to indicate that there is no executable pathname following.  */
     }
     else
       printf("Master environment is full - can't add \"%s\"\n", szBuf);

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -57,6 +57,7 @@ extern struct _KernelConfig InitKernelConfig;
 #define  memset     init_memset
 #define  strchr     init_strchr
 #define  strcpy     init_strcpy
+#define fstrcpy     init_fstrcpy
 #define  strlen     init_strlen
 #define fstrlen     init_fstrlen
 #endif
@@ -75,6 +76,7 @@ int    ASMPASCAL fmemcmp(const void FAR *m1, const void FAR *m2, size_t n);
 VOID   ASMPASCAL  memcpy(      void     *d,  const void     *s,  size_t n);
 VOID   ASMPASCAL fmemcpy(      void FAR *d,  const void FAR *s,  size_t n);
 VOID   ASMPASCAL  strcpy(char           *d,  const char     *s);
+VOID   ASMPASCAL fstrcpy(char       FAR *d,  const char FAR *s);
 size_t ASMPASCAL  strlen(const char     *s);
 size_t ASMPASCAL fstrlen(const char FAR *s);
 char * ASMPASCAL  strchr(const char     *s,  int ch);
@@ -90,6 +92,7 @@ char * ASMPASCAL  strchr(const char     *s,  int ch);
 #pragma aux (pascal_ax) memcmp modify nomemory
 #pragma aux (pascal_ax) fmemcmp modify nomemory
 #pragma aux (pascal_ax) strcpy
+#pragma aux (pascal_ax) fstrcpy
 #pragma aux (pascal_ax) strlen modify nomemory
 #pragma aux (pascal_ax) fstrlen modify nomemory
 #pragma aux (pascal) strchr modify exact [ax dx] nomemory
@@ -251,7 +254,7 @@ extern BYTE ASM _ib_start[], ASM _ib_end[], ASM _init_end[];
 extern UWORD ram_top;               /* How much ram in Kbytes               */
 extern char singleStep;
 extern char SkipAllConfig;
-extern char master_env[128];
+extern char FAR ASM master_env[128];
 
 extern struct lol FAR *LoL;
 

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -134,6 +134,8 @@ entry_common:
 
 beyond_entry:   times   256-(beyond_entry-entry) db 0
                                         ; scratch area for data (DOS_PSP)
+_master_env equ $ - 128
+global _master_env
 
 segment INIT_TEXT
 

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -148,6 +148,7 @@ SECTIONS
                 _init_memcpy = INIT_MEMCPY;
                 _init_fmemcpy = INIT_FMEMCPY;
                 _init_strcpy = INIT_STRCPY;
+                _init_fstrcpy = INIT_FSTRCPY;
                 _init_strlen = INIT_STRLEN;
                 _init_strchr = INIT_STRCHR;
                 _UMB_get_largest = UMB_GET_LARGEST;

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -106,6 +106,12 @@ VOID ASMCFUNC FreeDOSmain(void)
     drv = 3; /* C: */
   LoL->BootDrive = drv;
 
+  /* init master environment start */
+  *master_env = 0;
+  master_env[1] = 0;
+  master_env[2] = 0;
+  master_env[3] = 0;
+
   /* install DOS API and other interrupt service routines, basic kernel functionality works */
   setup_int_vectors();
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -466,7 +466,7 @@ STATIC void kernel()
   CommandTail Cmd;
 
   if (master_env[0] == '\0')   /* some shells panic on empty master env. */
-    fmemcpy(master_env, "PATH=.\0\0", sizeof("PATH=.\0\0"));
+    fmemcpy(master_env, "PATH=.\0\0\0\0", sizeof("PATH=.\0\0\0\0"));
 
   /* process 0       */
   /* Execute command.com from the drive we just booted from    */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -466,8 +466,7 @@ STATIC void kernel()
   CommandTail Cmd;
 
   if (master_env[0] == '\0')   /* some shells panic on empty master env. */
-    strcpy(master_env, "PATH=.");
-  fmemcpy(MK_FP(DOS_PSP + 8, 0), master_env, sizeof(master_env));
+    fmemcpy(master_env, "PATH=.\0\0", sizeof("PATH=.\0\0"));
 
   /* process 0       */
   /* Execute command.com from the drive we just booted from    */

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -68,7 +68,7 @@ ifeq ($(LOADSEG)0, 0)
 LOADSEG=0x60
 endif
 
-INITPATCH=ia16-elf-objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sym ___udivsi3=_init_udivsi3 --redefine-sym ___ashlsi3=_init_ashlsi3 --redefine-sym ___lshrsi3=_init_lshrsi3 --redefine-sym _printf=_init_printf --redefine-sym _sprintf=_init_sprintf --redefine-sym _execrh=_init_execrh --redefine-sym _memcpy=_init_memcpy --redefine-sym _fmemcpy=_init_fmemcpy --redefine-sym _fmemset=_init_fmemset --redefine-sym _fmemcmp=_init_fmemcmp --redefine-sym _memcmp=_init_memcmp --redefine-sym _memset=_init_memset --redefine-sym _strchr=_init_strchr --redefine-sym _strcpy=_init_strcpy --redefine-sym _strlen=_init_strlen --redefine-sym _fstrlen=_init_fstrlen --redefine-sym _open=_init_DosOpen
+INITPATCH=ia16-elf-objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sym ___udivsi3=_init_udivsi3 --redefine-sym ___ashlsi3=_init_ashlsi3 --redefine-sym ___lshrsi3=_init_lshrsi3 --redefine-sym _printf=_init_printf --redefine-sym _sprintf=_init_sprintf --redefine-sym _execrh=_init_execrh --redefine-sym _memcpy=_init_memcpy --redefine-sym _fmemcpy=_init_fmemcpy --redefine-sym _fmemset=_init_fmemset --redefine-sym _fmemcmp=_init_fmemcmp --redefine-sym _memcmp=_init_memcmp --redefine-sym _memset=_init_memset --redefine-sym _strchr=_init_strchr --redefine-sym _strcpy=_init_strcpy --redefine-sym _fstrcpy=_init_fstrcpy --redefine-sym _strlen=_init_strlen --redefine-sym _fstrlen=_init_fstrlen --redefine-sym _open=_init_DosOpen
 CLDEF=1
 CLT=gcc -Wall -DDOSC_TIME_H -I../hdr -o $@
 CLC=$(CLT)


### PR DESCRIPTION
Allows lDebug loaded as a device driver to access the environment variables set so far.