### PR TITLE
allow gcc build to succeed with -DWIN31SUPPORT

### DIFF
--- a/hdr/win.h
+++ b/hdr/win.h
@@ -18,6 +18,12 @@ struct WinStartupInfo
   ULONG optInstanceTable; /* used only if winver set to 0x400 (w95)*/
 };
 extern struct WinStartupInfo winStartupInfo;
+#if defined __GNUC__
+extern UWORD winseg1, winseg2, winseg3;
+extern UBYTE markEndInstanceData;
+extern struct lol ASM FAR DATASTART;
+#endif
+
 
 /* contains a list of offsets relative to DOS data segment of
    various internal variables.

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -2001,6 +2001,11 @@ VOID ASMCFUNC int2F_12_handler(struct int2f12regs FAR *pr)
         r.es = FP_SEG(&winStartupInfo);
         r.BX = FP_OFF(&winStartupInfo);
         winStartupInfo.winver = r.di;  /* match what caller says it is */
+#if defined __GNUC__
+	winseg1 = FP_SEG(&winStartupInfo);
+	winseg2 = FP_SEG(&DATASTART);
+	winseg3 = FP_OFF(&markEndInstanceData);
+#endif
         winInstanced = 1; /* internal flag marking Windows is active */
         DebugPrintf(("Win startup\n"));
         break;

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -607,11 +607,25 @@ _winStartupInfo:
                 dd 0 ; next startup info structure, 0:0h marks end
                 dd 0 ; far pointer to name virtual device file or 0:0h
                 dd 0 ; far pointer, reference data for virtual device driver
+ %ifnidni __OUTPUT_FORMAT__, elf
                 dw instance_table,seg instance_table ; array of instance data
+ %else
+                dw instance_table ; array of instance data
+global _winseg1
+_winseg1:	dw 0
+ %endif
 instance_table: ; should include stacks, Win may auto determine SDA region
                 ; we simply include whole DOS data segment
+ %ifnidni __OUTPUT_FORMAT__, elf
                 dw seg _DATASTART, 0 ; [SEG:OFF] address of region's base
-                dw markEndInstanceData wrt seg _DATASTART ; size in bytes
+                dw _markEndInstanceData wrt seg _DATASTART ; size in bytes
+ %else
+global _winseg2
+_winseg2:	dw 0
+                dw 0 ; [SEG:OFF] address of region's base
+global _winseg3
+_winseg3:	dw 0 ; size in bytes
+ %endif
                 dd 0 ; 0 marks end of table
                 dw 0 ; and 0 length for end of instance_table entry
                 global  _winPatchTable
@@ -975,7 +989,8 @@ segment DYN_DATA
 _Dyn:
         DynAllocated dw 0
 
-markEndInstanceData:  ; mark end of DOS data seg we say needs instancing
+global _markEndInstanceData
+_markEndInstanceData:  ; mark end of DOS data seg we say needs instancing
 
         
 segment ID_B


### PR DESCRIPTION
I copied `config.m` to `config.mak` and enabled the `-DWIN31SUPPORT` switch like so:

```
kwin31$ tail config.mak

# XFAT=16
XFAT=32

# Give extra compiler DEFINE flags here
# such as -DDEBUG : extra DEBUG output
#         -DDOSEMU : printf output goes to dosemu log
# set ALLCFLAGS=-DDEBUG
ALLCFLAGS=-DWIN31SUPPORT
NASMFLAGS=-DWIN31SUPPORT
```

(Is this correct? Is there a better way to set this flag?)

Prior to this commit building with `-DWIN31SUPPORT` would fail with errors from NASM:

```
nasm -Dgcc -DWIN31SUPPORT -DWITHFAT32 -i../hdr/ -DXCPU=386 -felf -o kernel.obj kernel.asm
kernel.asm:610: error: ELF format does not support segment base references
kernel.asm:613: error: ELF format does not support segment base references
kernel.asm:614: error: ELF format does not support this use of WRT
```

I did a small validity check on the resulting structure and it seems to be correct when I call [int 2Fh function 1605h](http://fd.lod.bz/rbil/interrup/windows/2f1605.html), however I do not know whether this works and have not tested or studied this extensively.