### PR TITLE
ecm fdconfig var del

### DIFF
--- a/kernel/asmsupt.asm
+++ b/kernel/asmsupt.asm
@@ -327,7 +327,6 @@ strcpy_loop:
 		jmp  short pascal_return
 
 ;******************************************************************                
-%ifndef _INIT                
                 global  FSTRLEN
 FSTRLEN:
                 call pascal_setup
@@ -337,7 +336,6 @@ FSTRLEN:
 		mov   bl,4
 
                 jmp short dostrlen
-%endif
 
 ;**********************************************
                 global  STRLEN

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -2751,9 +2751,8 @@ STATIC BYTE far * searchvar(const BYTE * name, int length)
   return NULL;
 }
 
-STATIC void deletevar(const BYTE * name, int length) {
+STATIC void deletevar(BYTE far * pp) {
   int variablelength;
-  BYTE far * pp = searchvar(name, length);
   if (NULL == pp)
     return;
   variablelength = fstrlen(pp) + 1;
@@ -2770,10 +2769,12 @@ STATIC VOID CmdSet(BYTE *pLine)
   if (*pLine == '=')      /* equal sign is required */
   {
     int size, namesize;
+    BYTE far * pp;
     strupr(szBuf);        /* all environment variables must be uppercase */
     namesize = strlen(szBuf);
     strcat(szBuf, "=");
-    deletevar(szBuf, namesize);
+    pp = searchvar(szBuf, namesize);
+    deletevar(pp);
     pLine = skipwh(++pLine);
     strcat(szBuf, pLine); /* append the variable value (may include spaces) */
     size = strlen(szBuf);

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -2739,6 +2739,30 @@ VOID DoInstall(void)
   return;
 }
 
+STATIC BYTE far * searchvar(const BYTE * name, int length)
+{
+  BYTE far * pp = master_env;
+  do {
+    if (!fmemcmp(name, pp, length + 1)) {
+      return pp;
+    }
+    pp += fstrlen(pp) + 1;
+  } while (*pp);
+  return NULL;
+}
+
+STATIC void deletevar(const BYTE * name, int length) {
+  int variablelength;
+  BYTE far * pp = searchvar(name, length);
+  if (NULL == pp)
+    return;
+  variablelength = fstrlen(pp) + 1;
+  fmemcpy(pp, pp + variablelength, envp + 3 - (pp + variablelength));
+  /* our fmemcpy always copies forwards */
+  envp -= variablelength;
+  return;
+}
+
 STATIC VOID CmdSet(BYTE *pLine)
 {
   pLine = GetStringArg(pLine, szBuf);
@@ -2747,7 +2771,9 @@ STATIC VOID CmdSet(BYTE *pLine)
   {
     int size;
     strupr(szBuf);        /* all environment variables must be uppercase */
+    size = strlen(szBuf);
     strcat(szBuf, "=");
+    deletevar(szBuf, size);
     pLine = skipwh(++pLine);
     strcat(szBuf, pLine); /* append the variable value (may include spaces) */
     size = strlen(szBuf);

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -2769,14 +2769,18 @@ STATIC VOID CmdSet(BYTE *pLine)
   pLine = skipwh(pLine);  /* scan() stops at the equal sign or space */
   if (*pLine == '=')      /* equal sign is required */
   {
-    int size;
+    int size, namesize;
     strupr(szBuf);        /* all environment variables must be uppercase */
-    size = strlen(szBuf);
+    namesize = strlen(szBuf);
     strcat(szBuf, "=");
-    deletevar(szBuf, size);
+    deletevar(szBuf, namesize);
     pLine = skipwh(++pLine);
     strcat(szBuf, pLine); /* append the variable value (may include spaces) */
     size = strlen(szBuf);
+    if (size == namesize + 1) {
+      /* empty variable ?  then just delete. */
+      return;
+    }
     if (size < master_env + sizeof(master_env) - envp - 1 - 2)
     {                     /* must end with two consequtive zeros */
       fstrcpy(envp, szBuf);

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -150,6 +150,7 @@ SECTIONS
                 _init_strcpy = INIT_STRCPY;
                 _init_fstrcpy = INIT_FSTRCPY;
                 _init_strlen = INIT_STRLEN;
+                _init_fstrlen = INIT_FSTRLEN;
                 _init_strchr = INIT_STRCHR;
                 _UMB_get_largest = UMB_GET_LARGEST;
 		_init_call_intr = INIT_CALL_INTR;


### PR DESCRIPTION
This allows to delete environment variables using an empty `set var=`, and will also delete an existing variable if the name of a variable to set matches an existing variable. (If after the deletion there would still not be enough space for the new variable, the error is displayed and the existing variable is unchanged.)

https://github.com/FDOS/kernel/pull/107 is not required but would still be good.