### PR TITLE
fix exeflat not deleting temporary file

### DIFF
--- a/utils/exeflat.c
+++ b/utils/exeflat.c
@@ -521,7 +521,11 @@ int main(int argc, char **argv)
   } else {
     tmpexe = "tmp.sys";
   }
-  rename(argv[2], tmpexe);
+  if (rename(argv[2], tmpexe))
+  {
+    printf("Can not rename %s to %s\n", argv[2], tmpexe);
+    exit(1);
+  }	
 
   len2 = strlen(tmpexe) + 1;
   sz = len2;
@@ -615,6 +619,6 @@ int main(int argc, char **argv)
 
   fclose(source);
   remove("tmp.bin");
-
+  remove(tmpexe);
   return 0;
 }


### PR DESCRIPTION
During build the kernel silently was not updated, because a temporary file could not be overwritten by exeflat (it was created by exeflat in a previous run).

The new behaviour is, that exeflat terminates with error, if the file renaming can not be performed. The temporary binary is also deleted after compressing the kernel.