### PR TITLE
initdisk: actually restrict disk size to 2TB instead of modulo 2TB, fix ExtLBAForce usage

### DIFF
--- a/kernel/initdisk.c
+++ b/kernel/initdisk.c
@@ -757,14 +757,12 @@ StandardBios:                  /* old way to get parameters */
       printf("BIOS reported 0 sectors/track, assuming 63!\n");
   }
 
-  /* if heads==0, determine from disk size like LBA assisted BIOS translation
-     does, or default to 16 if LBA is not used */
-  if (driveParam->chs.Head == 0) {
-    driveParam->chs.Head = (driveParam->descflags & DF_LBA)
-      ? BIOS_assisted_LBA_heads(driveParam->total_sectors)
-      : 16;
+  /* If heads < 2, this is probably wrong?!?
+     Then determine heads from disk size like BIOS assisted LBA does */
+  if (driveParam->chs.Head < 2) {
+    driveParam->chs.Head = BIOS_assisted_LBA_heads(driveParam->total_sectors);
     if (firstPass && (InitKernelConfig.Verbose >= 0))
-      printf("BIOS reported 0 heads, assuming %u!\n", driveParam->chs.Head);
+      printf("BIOS reported <2 heads, assuming %u!\n", driveParam->chs.Head);
   }
 
   if (!(driveParam->descflags & DF_LBA))

--- a/kernel/initdisk.c
+++ b/kernel/initdisk.c
@@ -630,15 +630,6 @@ void DosDefinePartition(struct DriveParamS *driveParam,
   nUnits++;
 }
 
-STATIC UWORD BIOS_assisted_LBA_heads(ULONG sectors)
-{
-  if      (sectors > 63ul * 128ul * 1024ul) return 255;
-  else if (sectors > 63ul * 64ul * 1024ul) return 128;
-  else if (sectors > 63ul * 32ul * 1024ul) return 64;
-  else if (sectors > 63ul * 16ul * 1024ul) return 32;
-  else return 16;
-}
-
 /* Get the parameters of the hard disk */
 STATIC int LBA_Get_Drive_Parameters(int drive, struct DriveParamS *driveParam, int firstPass)
 {
@@ -755,14 +746,6 @@ StandardBios:                  /* old way to get parameters */
     driveParam->chs.Sector = 63; /* avoid division by zero...! */
     if (firstPass && (InitKernelConfig.Verbose >= 0)) 
       printf("BIOS reported 0 sectors/track, assuming 63!\n");
-  }
-
-  /* If heads < 2, this is probably wrong?!?
-     Then determine heads from disk size like BIOS assisted LBA does */
-  if (driveParam->chs.Head < 2) {
-    driveParam->chs.Head = BIOS_assisted_LBA_heads(driveParam->total_sectors);
-    if (firstPass && (InitKernelConfig.Verbose >= 0))
-      printf("BIOS reported <2 heads, assuming %u!\n", driveParam->chs.Head);
   }
 
   if (!(driveParam->descflags & DF_LBA))


### PR DESCRIPTION
Hey Jeremy,

I had a look at the recent changes and found some places where I am not sure that it is correct. For instance, I think `ExtLBAForce` originally was meant to force LBA access for partitions contained inside an extended partition of type LBA (0x0E).

ExtLBAForce is now set in `LBA_Get_Drive_Parameters` to `InitKernelConfig.ForceLBA`. I understand you somewhat wanted to force the use of LBA (it is not clear to me in what case exactly), but setting `ExtLBAForce` in `LBA_Get_Drive_Parameters` is in my opinion a) the wrong variable and b) the wrong place for it.

I relocated the `ExtLBAForce` setting to `ProcessDisk`, setting it initially to zero. I think this is the right layer of abstraction for it. `LBA_Get_Drive_Parameters` should only do what it is named after: getting drive parameters. Otherwise it is getting even more confusing.

In this merge request I also restrict the disk size to 2TB. It was modulo 2TB before, leading to a 3TB disk becoming a 1TB disk.

It also includes other minor changes (should be reviewed).

Greetings, Bernd