### PR TITLE
ecm boot32 dl

### DIFF
--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -306,6 +306,7 @@ c3:
                 adc     dx, [data_start + 2]
                 ret
 
+%if 0
 ; prints text after call to this function.
 
 print_1char:        
@@ -318,7 +319,8 @@ print1:         lodsb                          ; get token
                 cmp   al, 0                    ; end of string?
                 jne   print_1char              ; until done
                 ret                            ; and jump to it
-                
+%endif
+
 ;input:
 ;   DX:AX - 32-bit DOS sector number
 ;   ES:BX - destination buffer

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -388,8 +388,10 @@ read_ok:
                 mov     es, cx
 
 no_incr_es:
-                add     ax,byte 1
-                adc     dx,byte 0
+		inc ax
+		jnz .no_carry
+		inc dx
+.no_carry:
                 ret
 
        times   0x01f1-$+$$ db 0

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -216,6 +216,10 @@ c6:
                 jmp     short c5
                 
 boot_error:
+		mov ax, 0E00h | '!'
+		int 10h				; display the error sign
+		mov al, 07h
+		int 10h				; beep
 		xor	ah,ah
 		int	0x16			; wait for a key
 		int	0x19			; reboot the machine

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -272,8 +272,9 @@ cn_exit:
                 ret
 
 
-boot_success:   
-                mov     bl, [drive]
+boot_success:
+		mov dl, [drive]			; for Enhanced DR-DOS load
+		mov bl, dl			; for FreeDOS load
 		jmp	far [loadsegoff_60]
 
 ; Convert cluster to the absolute sector

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -144,7 +144,7 @@ secshift:	inc	ax
 		shr	cx, 1
 		cmp	cx, 1
 		jne	secshift
-		mov	byte [fat_secshift], al
+		mov	word [fat_secshift], ax
 		dec	cx
  
 ;       FINDFILE: Searches for the file in the root directory.

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -236,8 +236,7 @@ next_cluster:
 cn_loop:
                 shr     dx,1
                 rcr     ax,1
-                dec     cx
-                jnz     cn_loop                ; DX:AX fat sector where our
+                loop    cn_loop                ; DX:AX fat sector where our
                                                ; cluster resides
                                                ; DI - cluster index in this
                                                ; sector

--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -242,7 +242,9 @@ rk_walk_fat:	pop	eax
 		
 ;-----------------------------------------------------------------------
 
-boot_success:	mov	bl, [drive]
+boot_success:
+		mov dl, [drive]			; for Enhanced DR-DOS load
+		mov bl, dl			; for FreeDOS load
 		jmp	far [loadsegoff_60]
 
 ;-----------------------------------------------------------------------


### PR DESCRIPTION
This fixes the incompatibility noted in #119 and also another bug of the 8086 CHS FAT32 loader. The latter prevented successful loading if the kernel file's clusters did not fit within the first FAT sector.

Also, the 8086 CHS FAT32 loader will now emit an exclamation mark and a beep when an error occurs, rather than staying silent.