### PR TITLE
rework update_dcb() to avoid potential access uninitialized memory

### DIFF
--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -519,7 +519,7 @@ _first_mcb      dw      0               ;-0002 Start of user memory
                 global  MARK0026H
 ; A reference seems to indicate that this should start at offset 26h.
 MARK0026H       equ     $
-_DPBp           dd      0               ; 0000 First drive Parameter Block
+_DPBp           dd      -1              ; 0000 First drive Parameter Block
                 global  _sfthead
 _sfthead        dd      0               ; 0004 System File Table head
                 global  _clock


### PR DESCRIPTION
fix error that probably never would happen where if nunits is 0 would overwrite nonexistent dpb next pointer with -1