### PR TITLE
Make build work on DOS

### DIFF
--- a/kernel/makefile
+++ b/kernel/makefile
@@ -43,7 +43,8 @@ kernel.exe:	$(TARGET).lnk $(OBJS) $(LIBS)
 		$(LINK) @$(TARGET).lnk;
 
 ../bin/country.sys:
-	cd ..$(DIRSEP)country && $(MAKE) all
+	cd ..$(DIRSEP)country
+        $(MAKE) all
 	$(CP) ..$(DIRSEP)country$(DIRSEP)country.sys ..$(DIRSEP)bin$(DIRSEP)country.sys
 
 clobber:        clean


### PR DESCRIPTION
Double ampersands are not supported by DOS command line interpreters. The previous would work only on Windows (2000 and higher, I think).