### PR TITLE
ecm boot overlap

### DIFF
--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -99,8 +99,8 @@ Entry:          jmp     short real_start
 
 %define LOADSEG         0x0060
 
-%define FATBUF          0x2000          ; offset of temporary buffer for FAT
-                                        ; chain
+%define CLUSTLIST       0x2000          ; offset of temporary buffer for FAT
+                                        ; chain cluster list
 
 ;       Some extra variables
 
@@ -294,7 +294,7 @@ ffDone:
                 push    ds
                 pop     es
                 mov     ds, [loadseg_60]
-                mov     di, FATBUF
+                mov     di, CLUSTLIST
 
 next_clust:     stosw                           ; store cluster number
                 mov     si, ax                  ; SI = cluster number
@@ -351,7 +351,7 @@ finished:       ; Mark end of FAT chain with 0, so we have a single
 
                 les     bx, [loadsegoff_60]   ; set ES:BX to load address 60:0
 
-                mov     si, FATBUF      ; set DS:SI to the FAT chain
+                mov     si, CLUSTLIST           ; set DS:SI to the FAT chain
 
 cluster_next:   lodsw                           ; AX = next cluster to read
                 or      ax, ax                  ; EOF?

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -88,70 +88,9 @@
   %error Must select one FS
 %endif
 
-
-%macro _appenddigitstrdef 2.nolist
-%substr %%ii "0123456789ABCDEF" (%2) + 1
-%strcat _%1 _%1,%%ii
-%endmacro
-
-		; %1 = name of single-line macro to set. will be prefixed by underscore
-		; %2 = number to write
-		; %3 = minimal number of hexits, 0..8. defaults to 1
-		;	(setting it to 0 with a number of 0 defines macro to "")
-%macro _autohexitsstrdef 2-3.nolist 1
-%if %3 > 8
- %error Minimal number of hexits 9 or more: %3
-%endif
-%define _%1 ""
-%if (%2) >= 1_0000_0000h
- %error Number has to use 9 or more hexits: %2
-%endif
-%if (%2) >= 1000_0000h || %3 >= 8
-_appenddigitstrdef %1, (%2 >> (7 * 4)) & 0Fh
-%endif
-%if (%2) >= 100_0000h || %3 >= 7
-_appenddigitstrdef %1, (%2 >> (6 * 4)) & 0Fh
-%endif
-%if (%2) >= 10_0000h || %3 >= 6
-_appenddigitstrdef %1, (%2 >> (5 * 4)) & 0Fh
-%endif
-%if (%2) >= 1_0000h || %3 >= 5
-_appenddigitstrdef %1, (%2 >> (4 * 4)) & 0Fh
-%endif
-%if (%2) >= 1000h || %3 >= 4
-_appenddigitstrdef %1, (%2 >> (3 * 4)) & 0Fh
-%endif
-%if (%2) >= 100h || %3 >= 3
-_appenddigitstrdef %1, (%2 >> (2 * 4)) & 0Fh
-%endif
-%if (%2) >= 10h || %3 >= 2
-_appenddigitstrdef %1, (%2 >> (1 * 4)) & 0Fh
-%endif
-%if (%2) >= 1h || %3 >= 1
-_appenddigitstrdef %1, (%2 >> (0 * 4)) & 0Fh
-%endif
-%endmacro
-
                 ; NOTE: sys must be updated if magic offsets change
-	%macro magicoffset 3.nolist
-%ifdef ISFAT12
-  %define SYSOFFSET %2
-%elifdef ISFAT16
-  %define SYSOFFSET %3
-%else
-  %define SYSOFFSET 0
-                ; Just a placeholder, so the proper error message
-                ;  will be shown when assembling without either
-                ;  of the ISFATx defines.
-%endif
-%assign NEWOFFSET $ - Entry
-%if NEWOFFSET != SYSOFFSET
- _autohexitsstrdef NEWOFFSETHEX, NEWOFFSET
- %strcat _NEWOFFSETHEX _NEWOFFSETHEX,'h'
- %deftok NEWOFFSET _NEWOFFSETHEX
- %error Magic offset %1 changed for FATFS, old=SYSOFFSET, new=NEWOFFSET
-%endif
-	%endmacro
+%assign ISFAT1216DUAL 1
+	%include "magic.mac"
 
 
 segment .text

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -88,6 +88,50 @@
   %error Must select one FS
 %endif
 
+
+%macro _appenddigitstrdef 2.nolist
+%substr %%ii "0123456789ABCDEF" (%2) + 1
+%strcat _%1 _%1,%%ii
+%endmacro
+
+		; %1 = name of single-line macro to set. will be prefixed by underscore
+		; %2 = number to write
+		; %3 = minimal number of hexits, 0..8. defaults to 1
+		;	(setting it to 0 with a number of 0 defines macro to "")
+%macro _autohexitsstrdef 2-3.nolist 1
+%if %3 > 8
+ %error Minimal number of hexits 9 or more: %3
+%endif
+%define _%1 ""
+%if (%2) >= 1_0000_0000h
+ %error Number has to use 9 or more hexits: %2
+%endif
+%if (%2) >= 1000_0000h || %3 >= 8
+_appenddigitstrdef %1, (%2 >> (7 * 4)) & 0Fh
+%endif
+%if (%2) >= 100_0000h || %3 >= 7
+_appenddigitstrdef %1, (%2 >> (6 * 4)) & 0Fh
+%endif
+%if (%2) >= 10_0000h || %3 >= 6
+_appenddigitstrdef %1, (%2 >> (5 * 4)) & 0Fh
+%endif
+%if (%2) >= 1_0000h || %3 >= 5
+_appenddigitstrdef %1, (%2 >> (4 * 4)) & 0Fh
+%endif
+%if (%2) >= 1000h || %3 >= 4
+_appenddigitstrdef %1, (%2 >> (3 * 4)) & 0Fh
+%endif
+%if (%2) >= 100h || %3 >= 3
+_appenddigitstrdef %1, (%2 >> (2 * 4)) & 0Fh
+%endif
+%if (%2) >= 10h || %3 >= 2
+_appenddigitstrdef %1, (%2 >> (1 * 4)) & 0Fh
+%endif
+%if (%2) >= 1h || %3 >= 1
+_appenddigitstrdef %1, (%2 >> (0 * 4)) & 0Fh
+%endif
+%endmacro
+
                 ; NOTE: sys must be updated if magic offsets change
 	%macro magicoffset 3.nolist
 %ifdef ISFAT12
@@ -102,6 +146,9 @@
 %endif
 %assign NEWOFFSET $ - Entry
 %if NEWOFFSET != SYSOFFSET
+ _autohexitsstrdef NEWOFFSETHEX, NEWOFFSET
+ %strcat _NEWOFFSETHEX _NEWOFFSETHEX,'h'
+ %deftok NEWOFFSET _NEWOFFSETHEX
  %error Magic offset %1 changed for FATFS, old=SYSOFFSET, new=NEWOFFSET
 %endif
 	%endmacro

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -99,7 +99,7 @@ Entry:          jmp     short real_start
 
 %define LOADSEG         0x0060
 
-%define CLUSTLIST       0x2000          ; offset of temporary buffer for FAT
+%define CLUSTLIST       0x2200          ; offset of temporary buffer for FAT
                                         ; chain cluster list
 
 ;       Some extra variables

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -264,6 +264,7 @@ real_start:
                 jmp     word 0x1FE0:cont
 
 loadseg_off     dw      0
+	magicoffset "loadseg", 5Ch, 5Ch
 loadseg_seg     dw      LOADSEG
 
 cont:
@@ -276,6 +277,7 @@ cont:
 ; in DL, however we work around this in SYS.COM by NOP'ing out the use of DL
 ; (formerly we checked for [drive]==0xff; update sys.c if code moves)
 ;
+	magicoffset "set unit", 66h, 66h
                 mov     [drive], dl     ; rely on BIOS drive number in DL
 
                 mov     LBA_SIZE, 10h
@@ -616,6 +618,7 @@ do_int13_read:
 
        times   0x01f1-$+$$ db 0
 
+	magicoffset "kernel name", 1F1h, 1F1h
 filename        db      "KERNEL  SYS",0,0
 
 sign            dw      0xAA55

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -459,7 +459,8 @@ read_next:
                 ;  of the ISFATx defines.
 %endif
 %if ($ - Entry) != LBA_TEST_OFFSET
-    %error Must update constant offset (LBA_TEST_OFFSET) to test dl,dl here and in sys.c for FATFS
+ %assign NEWOFFSET $ - Entry
+ %error Magic offset to LBA detection changed for FATFS, old=LBA_TEST_OFFSET, new=NEWOFFSET
 %endif
                 test    dl,dl                   ; don't use LBA addressing on A:
                 jz      read_normal_BIOS        ; might be a (buggy)

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -33,16 +33,16 @@
 ;	|BOOTSEC| loader relocates itself here first thing,
 ;	|RELOC.	|  before loading root directory/FAT/kernel file
 ;	|-------| 1FE0h:7C00h = 27A00h (158 KiB)
-;	|  gap  |
+;	|  gap  | PARAMS live here
 ;	|LBA PKT| LBA disk packet
 ;	|-------| 1FE0h:7BC0h = 279C0h (158 KiB)
-;	|  gap  |
+;	|  gap  | READADDR_* live here
 ;	|-------| 1FE0h:7BA0h = 279A0h (158 KiB)
-;	| STACK | below relocated loader, above sector buffer (size 2 KiB)
+;	| STACK | below relocated loader, above sector buffer (size 5.9 KiB)
 ;	...
-;	|-------|
-;	|SEC.BUF| sector buffer, used to avoid crossing 64 KiB DMA boundary
-;	|-------| 1FE0h:63A0h = 261A0h (152 KiB)
+;	|-------| 1FE0h:6400h = 26200h (152 KiB)
+;	|SEC.BUF| sector buffer, to avoid crossing 64 KiB DMA boundary (size 8 KiB)
+;	|-------| 1FE0h:4400h = 24200h (144 KiB)
 ;	...
 ;	|-------| 1FE0h:4380h = 24182h (144 KiB)
 ;	|CLUSTER| built from FAT, listing every cluster of the kernel file.
@@ -155,9 +155,9 @@ Entry:          jmp     short real_start
 %define LBA_SECTOR_32  word [LBA_PACKET+12]
 %define LBA_SECTOR_48  word [LBA_PACKET+14]
 
-%define READBUF 0x63A0 ; max 4KB buffer (min 2KB stack), == stacktop-0x1800
-%define READADDR_OFF   BP-0x60-0x1804    ; pointer within user buffer
-%define READADDR_SEG   BP-0x60-0x1802
+%define READBUF 0x4400                      ; max 8 KiB buffer
+%define READADDR_OFF   word BP-0x60         ; pointer within user buffer
+%define READADDR_SEG   word BP-0x60+2
 
 %define PARAMS LBA_PACKET+0x10
 ;%define RootDirSecs     PARAMS+0x0         ; # of sectors root dir uses

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -28,6 +28,10 @@
 
 ;%define MULTI_SEC_READ  1
 
+                ; NOTE: sys must be updated if magic offsets change
+%assign ISFAT1216DUAL 0
+	%include "magic.mac"
+
 
 segment	.text
 
@@ -96,12 +100,14 @@ real_start:     cld
 		jmp     word 0x1FE0:cont
 
 loadseg_off	dw	0
+	magicoffset "loadseg", 78h
 loadseg_seg	dw	LOADSEG
 
 cont:           mov     ds, ax
                 mov     ss, ax
                 lea     sp, [bp-0x20]
 		sti
+	magicoffset "set unit", 82h
                 mov     [drive], dl     ; BIOS passes drive number in DL
 
 ;                call    print
@@ -401,6 +407,7 @@ no_incr_es:
 
        times   0x01f1-$+$$ db 0
 
+	magicoffset "kernel name", 1F1h
 filename        db      "KERNEL  SYS",0,0
 
 sign            dw      0xAA55

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -66,7 +66,7 @@ Entry:          jmp     short real_start
 
 %define LOADSEG         0x0060
 
-%define FATSEG          0x2000
+%define FATSEG          0x2200
 
 %define fat_sector      bp+0x48         ; last accessed sector of the FAT
 

--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -1,31 +1,30 @@
-;	+--------+
-;	|        |
-;	|        |
-;	|--------| 4000:0000
-;	|        |
-;	|  FAT   |
-;	|        |
-;	|--------| 2000:0000
-;	|BOOT SEC|
-;	|RELOCATE|
-;	|--------| 1FE0:0000
-;	|        |
-;	|        |
-;	|        |
-;	|        |
-;	|--------|
-;	|BOOT SEC|
-;	|ORIGIN  | 07C0:0000
-;	|--------|
-;	|        |
-;	|        |
-;	|        |
-;	|--------|
-;	|KERNEL  |
-;	|LOADED  |
-;	|--------| 0060:0000
-;	|        |
-;	+--------+
+
+; Memory layout for the FreeDOS FAT32 single stage boot process:
+;
+;	...
+;	|-------| 1FE0h:7E00h = 27C00h (159 KiB)
+;	|BOOTSEC| loader relocates itself here first thing,
+;	|RELOC.	|  before loading root directory/FAT/kernel file
+;	|-------| 1FE0h:7C00h = 27A00h (158 KiB)
+;	| STACK | below relocated loader, above FAT sector (size 22 KiB)
+;	...
+;	|-------| 2200h:2000h = 24000h (144 KiB)
+;	|  FAT  | (only 1 sector buffered, maximum sector size 8 KiB)
+;	|-------| 2200h:0000h = 22000h (136 KiB)
+;	...
+;	|-------| 0000h:7E00h = 07E00h (31.5 KiB)
+;	|BOOTSEC| overwritten by the kernel, so the
+;	|ORIGIN | bootsector relocates itself up...
+;	|-------| 0000h:7C00h = 07C00h (31 KiB)
+;	...
+;	|-------|
+;	|KERNEL	| maximum size 128 KiB (overwrites bootsec origin)
+;	|LOADED	| (holds 1 sector directory buffer before kernel file load)
+;	|-------| 0060h:0000h = 00600h (1.5 KiB)
+;	...
+; The kernel load segment may be patched using the SYS /L switch.
+;  We support values between 0x60 and 0x200 here, with file size
+;  of up to 128 KiB (rounded to cluster size). Default is 0x60.
 
 ;%define MULTI_SEC_READ  1
 

--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -53,6 +53,11 @@
 ;  We support values between 0x60 and 0x200 here, with file size
 ;  of up to 128 KiB (rounded to cluster size). Default is 0x60.
 
+                ; NOTE: sys must be updated if magic offsets change
+%assign ISFAT1216DUAL 0
+	%include "magic.mac"
+
+
 segment	.text
 
 		org	0x7c00		; this is a boot sector
@@ -129,7 +134,9 @@ real_start:	cld
 		rep	movsw		; move boot code to the 0x1FE0:0x0000
 		jmp	word 0x1FE0:cont
 
-loadseg_off	dw	0, LOADSEG
+loadseg_off	dw	0
+	magicoffset "loadseg", 78h
+		dw	LOADSEG
 
 ; -------------
 
@@ -137,6 +144,7 @@ cont:		mov	ds, ax
 		mov	ss, ax		; stack and BP-relative moves up, too
                 lea     sp, [bp-0x20]
 		sti
+	magicoffset "set unit", 82h
 		mov	[drive], dl	; BIOS passes drive number in DL
 
 %ifndef QUIET
@@ -413,6 +421,7 @@ msg_BootError	db "No "
 		; currently, only "kernel.sys not found" gives a message,
 		; but read errors in data or root or fat sectors do not.
 
+	magicoffset "kernel name", 1F1h
 filename	db "KERNEL  SYS"
 
 sign		dw 0, 0xAA55

--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -85,7 +85,7 @@ Entry:		jmp	short real_start
 
 %define LOADSEG		0x0060
 
-%define FATSEG		0x2000
+%define FATSEG		0x2200
 
 %define	fat_secshift	fat_afterss-1	; each fat sector describes 2^??
 					; clusters (db) (selfmodifying)

--- a/boot/boot32lb.asm
+++ b/boot/boot32lb.asm
@@ -27,27 +27,31 @@
 
 
 ; Memory layout for the FreeDOS FAT32 single stage boot process:
-
+;
 ;	...
-;	|-------| 1FE0:7E00
-;	|BOOTSEC|
-;	|RELOC.	|
-;	|-------| 1FE0:7C00
+;	|-------| 1FE0h:7E00h = 27C00h (159 KiB)
+;	|BOOTSEC| loader relocates itself here first thing,
+;	|RELOC.	|  before loading root directory/FAT/kernel file
+;	|-------| 1FE0h:7C00h = 27A00h (158 KiB)
+;	| STACK | below relocated loader, above FAT sector (size 22 KiB)
 ;	...
-;	|-------| 2000:0200
-;	|  FAT  | (only 1 sector buffered)
-;	|-------| 2000:0000
+;	|-------| 2200h:2000h = 24000h (144 KiB)
+;	|  FAT  | (only 1 sector buffered, maximum sector size 8 KiB)
+;	|-------| 2200h:0000h = 22000h (136 KiB)
 ;	...
-;	|-------| 0000:7E00
+;	|-------| 0000h:7E00h = 07E00h (31.5 KiB)
 ;	|BOOTSEC| overwritten by the kernel, so the
 ;	|ORIGIN | bootsector relocates itself up...
-;	|-------| 0000:7C00
+;	|-------| 0000h:7C00h = 07C00h (31 KiB)
 ;	...
 ;	|-------|
-;	|KERNEL	| maximum size 134k (overwrites bootsec origin)
-;	|LOADED	| (holds 1 sector directory buffer before kernel load)
-;	|-------| 0060:0000
+;	|KERNEL	| maximum size 128 KiB (overwrites bootsec origin)
+;	|LOADED	| (holds 1 sector directory buffer before kernel file load)
+;	|-------| 0060h:0000h = 00600h (1.5 KiB)
 ;	...
+; The kernel load segment may be patched using the SYS /L switch.
+;  We support values between 0x60 and 0x200 here, with file size
+;  of up to 128 KiB (rounded to cluster size). Default is 0x60.
 
 segment	.text
 

--- a/boot/magic.mac
+++ b/boot/magic.mac
@@ -1,0 +1,65 @@
+
+; Public Domain 2024 by E. C. Masloch
+
+%macro _appenddigitstrdef 2.nolist
+%substr %%ii "0123456789ABCDEF" (%2) + 1
+%strcat _%1 _%1,%%ii
+%endmacro
+
+		; %1 = name of single-line macro to set. will be prefixed by underscore
+		; %2 = number to write
+		; %3 = minimal number of hexits, 0..8. defaults to 1
+		;	(setting it to 0 with a number of 0 defines macro to "")
+%macro _autohexitsstrdef 2-3.nolist 1
+%if %3 > 8
+ %error Minimal number of hexits 9 or more: %3
+%endif
+%define _%1 ""
+%if (%2) >= 1_0000_0000h
+ %error Number has to use 9 or more hexits: %2
+%endif
+%if (%2) >= 1000_0000h || %3 >= 8
+_appenddigitstrdef %1, (%2 >> (7 * 4)) & 0Fh
+%endif
+%if (%2) >= 100_0000h || %3 >= 7
+_appenddigitstrdef %1, (%2 >> (6 * 4)) & 0Fh
+%endif
+%if (%2) >= 10_0000h || %3 >= 6
+_appenddigitstrdef %1, (%2 >> (5 * 4)) & 0Fh
+%endif
+%if (%2) >= 1_0000h || %3 >= 5
+_appenddigitstrdef %1, (%2 >> (4 * 4)) & 0Fh
+%endif
+%if (%2) >= 1000h || %3 >= 4
+_appenddigitstrdef %1, (%2 >> (3 * 4)) & 0Fh
+%endif
+%if (%2) >= 100h || %3 >= 3
+_appenddigitstrdef %1, (%2 >> (2 * 4)) & 0Fh
+%endif
+%if (%2) >= 10h || %3 >= 2
+_appenddigitstrdef %1, (%2 >> (1 * 4)) & 0Fh
+%endif
+%if (%2) >= 1h || %3 >= 1
+_appenddigitstrdef %1, (%2 >> (0 * 4)) & 0Fh
+%endif
+%endmacro
+
+	%macro magicoffset 3.nolist
+%ifdef ISFAT12
+  %define SYSOFFSET %2
+%elifdef ISFAT16
+  %define SYSOFFSET %3
+%else
+  %define SYSOFFSET 0
+                ; Just a placeholder, so the proper error message
+                ;  will be shown when assembling without either
+                ;  of the ISFATx defines.
+%endif
+%assign NEWOFFSET $ - Entry
+%if NEWOFFSET != SYSOFFSET
+ _autohexitsstrdef NEWOFFSETHEX, NEWOFFSET
+ %strcat _NEWOFFSETHEX _NEWOFFSETHEX,'h'
+ %deftok NEWOFFSET _NEWOFFSETHEX
+ %error Magic offset %1 changed for FATFS, old=SYSOFFSET, new=NEWOFFSET
+%endif
+	%endmacro

--- a/boot/magic.mac
+++ b/boot/magic.mac
@@ -44,22 +44,33 @@ _appenddigitstrdef %1, (%2 >> (0 * 4)) & 0Fh
 %endif
 %endmacro
 
-	%macro magicoffset 3.nolist
-%ifdef ISFAT12
+	%macro magicoffset 2-3.nolist
+%if ISFAT1216DUAL
+ %ifdef ISFAT12
   %define SYSOFFSET %2
-%elifdef ISFAT16
+ %elifdef ISFAT16
   %define SYSOFFSET %3
-%else
+ %else
   %define SYSOFFSET 0
                 ; Just a placeholder, so the proper error message
                 ;  will be shown when assembling without either
                 ;  of the ISFATx defines.
+ %endif
+%else
+ %define SYSOFFSET %2
+ %ifnempty %3
+  %error Not in dual mode
+ %endif
 %endif
 %assign NEWOFFSET $ - Entry
 %if NEWOFFSET != SYSOFFSET
  _autohexitsstrdef NEWOFFSETHEX, NEWOFFSET
  %strcat _NEWOFFSETHEX _NEWOFFSETHEX,'h'
  %deftok NEWOFFSET _NEWOFFSETHEX
- %error Magic offset %1 changed for FATFS, old=SYSOFFSET, new=NEWOFFSET
+ %if ISFAT1216DUAL
+  %error Magic offset %1 changed for FATFS, old=SYSOFFSET, new=NEWOFFSET
+ %else
+  %error Magic offset %1 changed, old=SYSOFFSET, new=NEWOFFSET
+ %endif
 %endif
 	%endmacro

--- a/boot/magic.mac
+++ b/boot/magic.mac
@@ -44,7 +44,7 @@ _appenddigitstrdef %1, (%2 >> (0 * 4)) & 0Fh
 %endif
 %endmacro
 
-	%macro magicoffset 2-3.nolist
+	%macro magicoffset 2-4.nolist ,0
 %if ISFAT1216DUAL
  %ifdef ISFAT12
   %define SYSOFFSET %2
@@ -62,7 +62,7 @@ _appenddigitstrdef %1, (%2 >> (0 * 4)) & 0Fh
   %error Not in dual mode
  %endif
 %endif
-%assign NEWOFFSET $ - Entry
+%assign NEWOFFSET $ + %4 - Entry
 %if NEWOFFSET != SYSOFFSET
  _autohexitsstrdef NEWOFFSETHEX, NEWOFFSET
  %strcat _NEWOFFSETHEX _NEWOFFSETHEX,'h'

--- a/boot/makefile
+++ b/boot/makefile
@@ -8,22 +8,22 @@
 production:     fat12com.bin fat16com.bin fat32chs.bin fat32lba.bin oemfat12.bin oemfat16.bin
 
 fat12com.bin:    boot.asm magic.mac
-		$(NASM) -dISFAT12 $(NASMBOOTFLAGS) boot.asm -l$*.lst -ofat12com.bin
+		$(NASM) -dISFAT12 $(NASMBOOTFLAGS) boot.asm -lfat12com.lst -ofat12com.bin
 
 fat16com.bin:    boot.asm magic.mac
-		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) boot.asm -l$*.lst -ofat16com.bin
+		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) boot.asm -lfat16com.lst -ofat16com.bin
 
 fat32chs.bin:    boot32.asm magic.mac
-		$(NASM) $(NASMBOOTFLAGS) boot32.asm -l$*.lst -ofat32chs.bin
+		$(NASM) $(NASMBOOTFLAGS) boot32.asm -lfat32chs.lst -ofat32chs.bin
 
 fat32lba.bin:    boot32lb.asm magic.mac
-		$(NASM) $(NASMBOOTFLAGS) boot32lb.asm -l$*.lst -ofat32lba.bin
+		$(NASM) $(NASMBOOTFLAGS) boot32lb.asm -lfat32lba.lst -ofat32lba.bin
 
 oemfat12.bin:   oemboot.asm magic.mac
-		$(NASM) -dISFAT12 $(NASMBOOTFLAGS) oemboot.asm -l$*.lst -ooemfat12.bin
+		$(NASM) -dISFAT12 $(NASMBOOTFLAGS) oemboot.asm -loemfat12.lst -ooemfat12.bin
 
 oemfat16.bin:   oemboot.asm magic.mac
-		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) oemboot.asm -l$*.lst -ooemfat16.bin
+		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) oemboot.asm -loemfat16.lst -ooemfat16.bin
 
 clobber:        clean
 		-$(RM) *.bin status.me

--- a/boot/makefile
+++ b/boot/makefile
@@ -13,10 +13,10 @@ fat12com.bin:    boot.asm magic.mac
 fat16com.bin:    boot.asm magic.mac
 		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) boot.asm -l$*.lst -ofat16com.bin
 
-fat32chs.bin:    boot32.asm
+fat32chs.bin:    boot32.asm magic.mac
 		$(NASM) $(NASMBOOTFLAGS) boot32.asm -l$*.lst -ofat32chs.bin
 
-fat32lba.bin:    boot32lb.asm
+fat32lba.bin:    boot32lb.asm magic.mac
 		$(NASM) $(NASMBOOTFLAGS) boot32lb.asm -l$*.lst -ofat32lba.bin
 
 oemfat12.bin:   oemboot.asm

--- a/boot/makefile
+++ b/boot/makefile
@@ -7,10 +7,10 @@
 
 production:     fat12com.bin fat16com.bin fat32chs.bin fat32lba.bin oemfat12.bin oemfat16.bin
 
-fat12com.bin:    boot.asm
+fat12com.bin:    boot.asm magic.mac
 		$(NASM) -dISFAT12 $(NASMBOOTFLAGS) boot.asm -l$*.lst -ofat12com.bin
 
-fat16com.bin:    boot.asm
+fat16com.bin:    boot.asm magic.mac
 		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) boot.asm -l$*.lst -ofat16com.bin
 
 fat32chs.bin:    boot32.asm

--- a/boot/makefile
+++ b/boot/makefile
@@ -19,10 +19,10 @@ fat32chs.bin:    boot32.asm magic.mac
 fat32lba.bin:    boot32lb.asm magic.mac
 		$(NASM) $(NASMBOOTFLAGS) boot32lb.asm -l$*.lst -ofat32lba.bin
 
-oemfat12.bin:   oemboot.asm
+oemfat12.bin:   oemboot.asm magic.mac
 		$(NASM) -dISFAT12 $(NASMBOOTFLAGS) oemboot.asm -l$*.lst -ooemfat12.bin
 
-oemfat16.bin:   oemboot.asm
+oemfat16.bin:   oemboot.asm magic.mac
 		$(NASM) -dISFAT16 $(NASMBOOTFLAGS) oemboot.asm -l$*.lst -ooemfat16.bin
 
 clobber:        clean

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1656,12 +1656,12 @@ void put_boot(SYSOptions *opts)
     if (opts->kernel.stdbs)
     {
       /* magic offset: loadsegoff_60 */
-      int defaultload = ((int *)newboot)[0x78/sizeof(int)];
+      int defaultload = *(int *)(&newboot[0x78]);
       if (defaultload != 0x60 && defaultload != 0x70) {
         printf("%s: Internal error: FAT32 load seg unexpected content\n", pgm);
         exit(1);
       }
-      ((int *)newboot)[0x78/sizeof(int)] = opts->kernel.loadaddr;
+      *(int *)(&newboot[0x78]) = opts->kernel.loadaddr;
       bsBiosMovOff = 0x82;	/* magic offset: mov byte [bp + 40h], dl */
     }
     else /* compatible bs */
@@ -1702,14 +1702,14 @@ void put_boot(SYSOptions *opts)
     if (opts->kernel.stdbs)
     {
       /* magic offset: loadsegoff_60 */
-      int defaultload = ((int *)newboot)[0x5C/sizeof(int)];
+      int defaultload = *(int *)(&newboot[0x5C]);
       if (defaultload != 0x60 && defaultload != 0x70) {
         printf("%s: Internal error: FAT1%c load seg unexpected content\n",
         	pgm, fs == FAT12 ? '2' : '6');
         exit(1);
       }
       /* this sets the segment we load the kernel to, default is 0x60:0 */
-      ((int *)newboot)[0x5c/sizeof(int)] = opts->kernel.loadaddr;
+      *(int *)(&newboot[0x5C]) = opts->kernel.loadaddr;
       bsBiosMovOff = 0x66;	/* magic offset: mov byte [bp + 24h], dl */
     }
     else
@@ -1719,12 +1719,12 @@ void put_boot(SYSOptions *opts)
       /* this however changes the offset jumped to default 0x70:0       */
       if (fs == FAT12) {
         /* magic offset: jmp LOADSEG:xxxxh */
-        defaultload = ((int *)newboot)[0x11A/sizeof(int)];
-        ((int *)newboot)[0x11A/sizeof(int)] = opts->kernel.loadaddr;
+        defaultload = *(int *)(&newboot[0x11A]);
+        *(int *)(&newboot[0x11A]) = opts->kernel.loadaddr;
       } else {
         /* magic offset: jmp LOADSEG:xxxxh */
-        defaultload = ((int *)newboot)[0x118/sizeof(int)];
-        ((int *)newboot)[0x118/sizeof(int)] = opts->kernel.loadaddr;
+        defaultload = *(int *)(&newboot[0x118]);
+        *(int *)(&newboot[0x118]) = opts->kernel.loadaddr;
       }
       if (defaultload != 0x0 && defaultload != 0x200) {
         printf("%s: Internal error: OEM FAT1%c load ofs unexpected content\n",

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1719,8 +1719,8 @@ void put_boot(SYSOptions *opts)
       /* this however changes the offset jumped to default 0x70:0       */
       if (fs == FAT12) {
         /* magic offset: jmp LOADSEG:xxxxh */
-        defaultload = ((int *)newboot)[0x11c/sizeof(int)];
-        ((int *)newboot)[0x11c/sizeof(int)] = opts->kernel.loadaddr;
+        defaultload = ((int *)newboot)[0x11A/sizeof(int)];
+        ((int *)newboot)[0x11A/sizeof(int)] = opts->kernel.loadaddr;
       } else {
         /* magic offset: jmp LOADSEG:xxxxh */
         defaultload = ((int *)newboot)[0x119/sizeof(int)];

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1723,8 +1723,8 @@ void put_boot(SYSOptions *opts)
         ((int *)newboot)[0x11A/sizeof(int)] = opts->kernel.loadaddr;
       } else {
         /* magic offset: jmp LOADSEG:xxxxh */
-        defaultload = ((int *)newboot)[0x119/sizeof(int)];
-        ((int *)newboot)[0x119/sizeof(int)] = opts->kernel.loadaddr;
+        defaultload = ((int *)newboot)[0x118/sizeof(int)];
+        ((int *)newboot)[0x118/sizeof(int)] = opts->kernel.loadaddr;
       }
       if (defaultload != 0x0 && defaultload != 0x200) {
         printf("%s: Internal error: OEM FAT1%c load ofs unexpected content\n",

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1762,6 +1762,7 @@ void put_boot(SYSOptions *opts)
   
   {
     int i = 0;
+    /* magic offset: (first) kernel filename */
     memset(&newboot[0x1f1], ' ', 11);
     while (opts->kernel.kernel[i] && opts->kernel.kernel[i] != '.')
     {


### PR DESCRIPTION
Several boot loader improvements:

- Bug #127 fixed, files up to 128 KiB rounded up size work now
- Load segment 0x60 to 0x200 fully supported
- Memory map comments fixed and updated
- SYS checks that it seems to patch the correct magic offsets
- Mark all magic offsets in SYS and the loader sources
- On magic offset mismatch the new offset is displayed by the NASM error message
- Create listing files with correct names, fixes bug #97