### PR TITLE
fix issue #144 by correcting getbpb return code

### DIFF
--- a/kernel/dsk.c
+++ b/kernel/dsk.c
@@ -480,14 +480,14 @@ STATIC WORD getbpb(ddt * pddt)
   printf("BPB_HUGE      = %08lx\n", pbpbarray->bpb_huge);
 #endif
 
-  return 0;
+  return S_DONE;
 }
 
 STATIC WORD bldbpb(rqptr rp, ddt * pddt)
 {
   WORD result;
 
-  if ((result = getbpb(pddt)) != 0)
+  if ((result = getbpb(pddt)) != S_DONE)
     return result;
 
   rp->r_bpptr = &pddt->ddt_bpb;

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1820,7 +1820,7 @@ VOID ASMCFUNC int2526_handler(WORD mode, struct int25regs FAR * r)
   else
     mode = DSKREADINT25;
 
-  drv = r->ax;
+  drv = r->ax & 0x7f; /* mask high bit of AL, may be set for disks>32M */ 
 
   if (drv >= lastdrive)
   {


### PR DESCRIPTION
Also mask high AL bit for INT25,26. Maybe set for drives >32M