### PR TITLE
ow-build-linux: enable patchobj utility compilation by OW on Linux

### DIFF
--- a/utils/patchobj.c
+++ b/utils/patchobj.c
@@ -13,7 +13,7 @@
 *****************************************************************************/
 
 #include <stdio.h>
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__WATCOMC__)
 #include <unistd.h>
 #else
 #include <io.h>


### PR DESCRIPTION
Use unistd.h header file instead of io.h to build on any OW supported host.