### PR TITLE
code-mismatch: fix various kernel code discrepancies which break TURB…

### DIFF
--- a/kernel/config.c
+++ b/kernel/config.c
@@ -62,7 +62,7 @@ STATIC struct MenuSelector MenuStruct[MENULINESMAX] BSS_INIT({0});
 
 int nMenuLine BSS_INIT(0);
 int MenuColor = -1;
-extern char kernel_command_line[256];
+extern char ASM kernel_command_line[256];
 extern int kernel_command_line_length;
 
 STATIC void WriteMenuLine(struct MenuSelector *menu)

--- a/kernel/dosfns.c
+++ b/kernel/dosfns.c
@@ -921,12 +921,12 @@ COUNT DosGetExtFree(BYTE FAR * DriveString, struct xfreespace FAR * xfsp)
       total = (((UDWORD)rg[0] << 16UL) | rg[1]);
       avail = (((UDWORD)rg[2] << 16UL) | rg[3]);
 
-      while (total > 0x00ffffff && spc < 128) {
+      while (total > 0x00ffffffUL && spc < 128) {
         spc *= 2;
         avail /= 2;
         total /= 2;
       }
-      while (total > 0x00ffffff && bps < 32768) {
+      while (total > 0x00ffffffUL && bps < 32768UL) {
         bps *= 2;
         avail /= 2;
         total /= 2;

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -38,7 +38,7 @@
 #define BSS_INIT(x)
 #endif
 
-extern struct _KernelConfig InitKernelConfig;
+extern struct _KernelConfig ASM InitKernelConfig;
 
 /*
  * Functions in `INIT_TEXT' may need to call functions in `_TEXT'. The entry

--- a/kernel/initdisk.c
+++ b/kernel/initdisk.c
@@ -714,7 +714,7 @@ STATIC int LBA_Get_Drive_Parameters(int drive, struct DriveParamS *driveParam, i
   else
   {
     if (firstPass) printf("Drive %02x is too large to handle, restricted to 2TB\n", drive);
-    driveParam->total_sectors = 0xffffffffu;
+    driveParam->total_sectors = 0xffffffffUL;
   }
 
   /* if we arrive here, mark drive as LBA capable */

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1916,7 +1916,7 @@ struct int2f12regs {
   UWORD callerARG1;             /* used if called from INT2F/12 */
 };
 
-extern intvec BIOSInt13, UserInt13, BIOSInt19;
+extern intvec ASM BIOSInt13, ASM UserInt13, ASM BIOSInt19;
 
 
 /* WARNING: modifications in `r' are used outside of int2F_12_handler()
@@ -2405,7 +2405,7 @@ VOID ASMCFUNC int2F_12_handler(struct int2f12regs FAR *pr)
         if (cdsp->cdsFlags)
         {
           TempCDS.cdsDpb = cdsp->cdsDpb;
-          TempCDS.cdsFlags = CDSPHYSDRV;    // don't inherit CDS flags
+          TempCDS.cdsFlags = CDSPHYSDRV;    /* don't inherit CDS flags */
         }
         else
         {

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -68,10 +68,10 @@ __segment DosTextSeg = 0;
 
 struct lol FAR *LoL = &DATASTART;
 
-struct _KernelConfig InitKernelConfig = { -1 };
-char kernel_command_line[256] = { 0, -1 }; /* special none value */
+struct _KernelConfig ASM InitKernelConfig = { -1 };
+char ASM kernel_command_line[256] = { 0, -1 }; /* special none value */
 int kernel_command_line_length BSS_INIT(0);
-UBYTE debugger_present = 0xFF;	/* initialised in kernel.asm
+UBYTE ASM debugger_present = 0xFF;	/* initialised in kernel.asm
 				   do NOT set 0 here or compiler may
 				   move it into bss that we zero out */
 

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1505,7 +1505,7 @@ void put_boot(SYSOptions *opts)
     clusters = dataSectors / (((bs32->bsSecPerClust - 1) & 0xFF) + 1);
 
     if (bs32->bsFATsecs == 0) {
-      if (clusters >= 0xFFFfff5) {     /* FAT32 has 28 significant bits */
+      if (clusters >= 0xFFFfff5UL) {     /* FAT32 has 28 significant bits */
         printf("Too many clusters (%lXh) for FAT32 file system!\n", clusters);
         exit(1);
       }


### PR DESCRIPTION
…O C build

- main issue is missing ASM attributes that C and asm code uses different names
- correct long constant by standard suffix 'L' or 'UL'