### PR TITLE
makefiles: restructure and fix some issues with various make tools

### DIFF
--- a/mkfiles/bc3.mak
+++ b/mkfiles/bc3.mak
@@ -4,11 +4,28 @@
 
 # Use these for Borland C 3.1
 
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KT3
+
+TARGETOPT=-1-
+!if $(XCPU) == 186
+TARGETOPT=-1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(BC3_BASE)
 COMPILERBIN=$(COMPILERPATH)\bin
 CC=$(COMPILERBIN)\bcc -c
 CL=$(COMPILERBIN)\bcc
-INCLUDEPATH=$(COMPILERPATH)\include
+INCLUDEPATH1=-I$(COMPILERPATH)\include
 LIBUTIL=$(COMPILERBIN)\tlib
 LIBPATH=$(COMPILERPATH)\lib
 LIBTERM=
@@ -17,8 +34,6 @@ LIBPLUS=+
 TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
-
-TARGET=KT3
 
 # used for building the library
 
@@ -31,19 +46,19 @@ MATH_INSERT=+H_LDIV +H_LLSH +H_LURSH +F_LXMUL
 # Compiler and Options for Borland C++
 # ------------------------------------
 #
-#  -zAname       ¦ ¦ Code class
-#  -zBname       ¦ ¦ BSS class
-#  -zCname       ¦ ¦ Code segment
-#  -zDname       ¦ ¦ BSS segment
-#  -zEname       ¦ ¦ Far segment
-#  -zFname       ¦ ¦ Far class
-#  -zGname       ¦ ¦ BSS group
-#  -zHname       ¦ ¦ Far group
-#  -zPname       ¦ ¦ Code group
-#  -zRname       ¦ ¦ Data segment
-#  -zSname       ¦ ¦ Data group
-#  -zTname       ¦ ¦ Data class
-#  -zX           ¦«¦ Use default name for "X"
+#  -zAname       ï¿½ ï¿½ Code class
+#  -zBname       ï¿½ ï¿½ BSS class
+#  -zCname       ï¿½ ï¿½ Code segment
+#  -zDname       ï¿½ ï¿½ BSS segment
+#  -zEname       ï¿½ ï¿½ Far segment
+#  -zFname       ï¿½ ï¿½ Far class
+#  -zGname       ï¿½ ï¿½ BSS group
+#  -zHname       ï¿½ ï¿½ Far group
+#  -zPname       ï¿½ ï¿½ Code group
+#  -zRname       ï¿½ ï¿½ Data segment
+#  -zSname       ï¿½ ï¿½ Data group
+#  -zTname       ï¿½ ï¿½ Data class
+#  -zX           ï¿½ï¿½ï¿½ Use default name for "X"
 
 #
 # ALLCFLAGS specified by turbo.cfg and config.mak

--- a/mkfiles/bc5.mak
+++ b/mkfiles/bc5.mak
@@ -4,11 +4,28 @@
 
 # Use these for Borland C++
 
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KBC
+
+TARGETOPT=-1-
+!if $(XCPU) == 186
+TARGETOPT=-1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(BC5_BASE)
 COMPILERBIN=$(COMPILERPATH)\bin
 CC=$(COMPILERBIN)\bcc -c
 CL=$(COMPILERBIN)\bcc
-INCLUDEPATH=$(COMPILERPATH)\include
+INCLUDEPATH1=-I$(COMPILERPATH)\include
 LIBUTIL=$(COMPILERBIN)\tlib
 LIBPATH=$(COMPILERPATH)\lib
 LIBTERM=  
@@ -17,8 +34,6 @@ LIBPLUS=+
 TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
-
-TARGET=KBC
 
 # used for building the library
 
@@ -31,19 +46,19 @@ MATH_INSERT=+H_LDIV +H_LLSH +H_LURSH +F_LXMUL
 # Compiler and Options for Borland C++
 # ------------------------------------
 #
-#  -zAname       ¦ ¦ Code class
-#  -zBname       ¦ ¦ BSS class
-#  -zCname       ¦ ¦ Code segment
-#  -zDname       ¦ ¦ BSS segment
-#  -zEname       ¦ ¦ Far segment
-#  -zFname       ¦ ¦ Far class
-#  -zGname       ¦ ¦ BSS group
-#  -zHname       ¦ ¦ Far group
-#  -zPname       ¦ ¦ Code group
-#  -zRname       ¦ ¦ Data segment
-#  -zSname       ¦ ¦ Data group
-#  -zTname       ¦ ¦ Data class
-#  -zX           ¦«¦ Use default name for "X"
+#  -zAname       ï¿½ ï¿½ Code class
+#  -zBname       ï¿½ ï¿½ BSS class
+#  -zCname       ï¿½ ï¿½ Code segment
+#  -zDname       ï¿½ ï¿½ BSS segment
+#  -zEname       ï¿½ ï¿½ Far segment
+#  -zFname       ï¿½ ï¿½ Far class
+#  -zGname       ï¿½ ï¿½ BSS group
+#  -zHname       ï¿½ ï¿½ Far group
+#  -zPname       ï¿½ ï¿½ Code group
+#  -zRname       ï¿½ ï¿½ Data segment
+#  -zSname       ï¿½ ï¿½ Data group
+#  -zTname       ï¿½ ï¿½ Data class
+#  -zX           ï¿½ï¿½ï¿½ Use default name for "X"
 
 #
 # ALLCFLAGS specified by turbo.cfg and config.mak

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -8,8 +8,8 @@
 #**********************************************************************
 
 TARGET=KGC$(XCPU)$(XFAT)
-TARGETOPT=-march=i8086
 
+TARGETOPT=-march=i8086
 ifeq ($(XCPU),186)
 TARGETOPT=march=i80186
 ALLCFLAGS+=-DI186
@@ -29,7 +29,6 @@ NASMFLAGS+=-i../hdr/ -DXCPU=$(XCPU) -felf
 
 CC=ia16-elf-gcc -c
 CL=ia16-elf-gcc
-INCLUDEPATH=.
 
 LIBUTIL=ar crs
 LIBPLUS=

--- a/mkfiles/generic.mak
+++ b/mkfiles/generic.mak
@@ -1,21 +1,5 @@
 # These are generic definitions
 
-#**********************************************************************
-#* TARGET    : we create a %TARGET%.sys file
-#* TARGETOPT : options, handled down to the compiler
-#**********************************************************************
-
-TARGETOPT=-1-
-
-!if $(XCPU) == 186
-TARGETOPT=-1
-ALLCFLAGS=$(ALLCFLAGS) -DI186
-!endif
-!if $(XCPU) == 386
-TARGETOPT=-3
-ALLCFLAGS=$(ALLCFLAGS) -DI386
-!endif
-
 !if $(XFAT) == 32
 ALLCFLAGS=$(ALLCFLAGS) -DWITHFAT32
 NASMFLAGS=$(NASMFLAGS) -DWITHFAT32
@@ -40,8 +24,9 @@ LOADSEG=0x60
 !include "../mkfiles/$(COMPILER).mak"
 
 !if $(CLDEF) == 0
-CLT=$(CL) $(CFLAGST) $(TINY) -I$(INCLUDEPATH)
-CLC=$(CL) $(CFLAGSC) -I$(INCLUDEPATH)
+INCLUDEPATH2=$(INCLUDEPATH1)
+CLT=$(CL) $(CFLAGST) $(TINY)
+CLC=$(CL) $(CFLAGSC)
 !endif
 
 TARGET=$(TARGET)$(XCPU)$(XFAT)

--- a/mkfiles/mscl8.mak
+++ b/mkfiles/mscl8.mak
@@ -3,9 +3,27 @@
 #
 
 # Use these for MSCV 1.52
+
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KMS
+
+TARGETOPT=
+!if $(XCPU) == 186    
+TARGETOPT=-G1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-G3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(MS_BASE)
 COMPILERBIN=$(COMPILERPATH)\bin
-INCLUDEPATH=$(COMPILERPATH)\include
+INCLUDEPATH1=-I$(COMPILERPATH)\include
 CC=$(COMPILERBIN)\cl -c
 CL=$(COMPILERBIN)\cl
 TINY=
@@ -17,24 +35,12 @@ INCLUDE=$(COMPILERPATH)\include
 LIBUTIL=$(COMPILERBIN)\lib /nologo
 LIBPLUS=+
 LIBTERM=;
-INCLUDE=$(COMPILERPATH)\include
-LIB=$(COMPILERPATH)\lib
 
 # used for building the library
 
 CLIB=$(COMPILERPATH)\lib\slibce.lib
 MATH_EXTRACT=*aflmul *aFlshl *aFNaulsh *aFNauldi *aFulrem *aFulshr *aFuldiv *aFlrem *aFldiv
 MATH_INSERT= +aflmul +aFlshl +aFNaulsh +aFNauldi +aFulrem +aFulshr +aFuldiv +aFlrem +aFldiv
-
-TARGETOPT=
-!if $(XCPU) == 186    
-TARGETOPT=-G1
-!endif
-!if $(XCPU) == 386
-TARGETOPT=-G3
-!endif
-
-TARGET=KMS
 
 #
 # heavy stuff - building

--- a/mkfiles/owwin.mak
+++ b/mkfiles/owwin.mak
@@ -7,13 +7,14 @@ include "../mkfiles/watcom.mak"
 
 DIRSEP=\ 
 
-INCLUDEPATH=$(COMPILERPATH)\h
+INCLUDEPATH1=-I$(COMPILERPATH)\h
+INCLUDEPATH2=-I$(COMPILERPATH)\h -I$(COMPILERPATH)\h\nt
 #RM=del 2>nul
 #CP=copy
 #ECHOTO=echo>>
 #INITPATCH=@echo > nul
 CLDEF=1
-CLT=wcl386 -zq -bcl=nt -I..\hdr -fe=$@ -I$(COMPILERPATH)\h -I$(COMPILERPATH)\h\nt
+CLT=wcl386 -zq -bcl=nt -I..\hdr -fe=$@
 CLC=$(CLT)
 NASMFLAGS=-DWATCOM $(NASMFLAGS)
 XLINK=$(XLINK) debug all format dos opt quiet,symfile,map,statics,verbose F { $(OBJS) } L ..$(DIRSEP)lib$(DIRSEP)device.lib N kernel.exe $#

--- a/mkfiles/tc2.mak
+++ b/mkfiles/tc2.mak
@@ -4,11 +4,28 @@
 
 # Use these for Turbo C 2.01
 
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KTC
+
+TARGETOPT=-1-
+!if $(XCPU) == 186
+TARGETOPT=-1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(TC2_BASE)
 COMPILERBIN=$(COMPILERPATH)
 CC=$(COMPILERBIN)\tcc -c
 CL=$(COMPILERBIN)\tcc
-INCLUDEPATH=$(COMPILERPATH)\include
+INCLUDEPATH1=-I$(COMPILERPATH)\include
 LIBUTIL=$(COMPILERBIN)\tlib
 LIBPATH=$(COMPILERPATH)\lib
 LIBTERM=  
@@ -17,8 +34,6 @@ LIBPLUS=+
 TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d -w
 CFLAGSC=-L$(LIBPATH) -a- -mc
-
-TARGET=KTC
 
 # used for building the library
 
@@ -31,19 +46,19 @@ MATH_INSERT=+LDIV +LXMUL  +LURSH +LLSH +LRSH
 # Compiler and Options for Borland C++
 # ------------------------------------
 #
-#  -zAname       ¦ ¦ Code class
-#  -zBname       ¦ ¦ BSS class
-#  -zCname       ¦ ¦ Code segment
-#  -zDname       ¦ ¦ BSS segment
-#  -zEname       ¦ ¦ Far segment
-#  -zFname       ¦ ¦ Far class
-#  -zGname       ¦ ¦ BSS group
-#  -zHname       ¦ ¦ Far group
-#  -zPname       ¦ ¦ Code group
-#  -zRname       ¦ ¦ Data segment
-#  -zSname       ¦ ¦ Data group
-#  -zTname       ¦ ¦ Data class
-#  -zX           ¦«¦ Use default name for "X"
+#  -zAname       ï¿½ ï¿½ Code class
+#  -zBname       ï¿½ ï¿½ BSS class
+#  -zCname       ï¿½ ï¿½ Code segment
+#  -zDname       ï¿½ ï¿½ BSS segment
+#  -zEname       ï¿½ ï¿½ Far segment
+#  -zFname       ï¿½ ï¿½ Far class
+#  -zGname       ï¿½ ï¿½ BSS group
+#  -zHname       ï¿½ ï¿½ Far group
+#  -zPname       ï¿½ ï¿½ Code group
+#  -zRname       ï¿½ ï¿½ Data segment
+#  -zSname       ï¿½ ï¿½ Data group
+#  -zTname       ï¿½ ï¿½ Data class
+#  -zX           ï¿½ï¿½ï¿½ Use default name for "X"
 
 #
 # ALLCFLAGS specified by turbo.cfg and config.mak

--- a/mkfiles/tc3.mak
+++ b/mkfiles/tc3.mak
@@ -4,11 +4,28 @@
 
 # Use these for Turbo C 3.0
 
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KT3
+
+TARGETOPT=-1-
+!if $(XCPU) == 186
+TARGETOPT=-1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(TC3_BASE)
 COMPILERBIN=$(COMPILERPATH)\bin
 CC=$(COMPILERBIN)\tcc -c
 CL=$(COMPILERBIN)\tcc
-INCLUDEPATH=$(COMPILERPATH)\include
+INCLUDEPATH1=-I$(COMPILERPATH)\include
 LIBUTIL=$(COMPILERBIN)\tlib
 LIBPATH=$(COMPILERPATH)\lib
 LIBTERM=  
@@ -17,8 +34,6 @@ LIBPLUS=+
 TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
-
-TARGET=KT3
 
 # used for building the library
 
@@ -31,19 +46,19 @@ MATH_INSERT=+H_LDIV +H_LLSH +H_LURSH +F_LXMUL
 # Compiler and Options for Borland C++
 # ------------------------------------
 #
-#  -zAname       ¦ ¦ Code class
-#  -zBname       ¦ ¦ BSS class
-#  -zCname       ¦ ¦ Code segment
-#  -zDname       ¦ ¦ BSS segment
-#  -zEname       ¦ ¦ Far segment
-#  -zFname       ¦ ¦ Far class
-#  -zGname       ¦ ¦ BSS group
-#  -zHname       ¦ ¦ Far group
-#  -zPname       ¦ ¦ Code group
-#  -zRname       ¦ ¦ Data segment
-#  -zSname       ¦ ¦ Data group
-#  -zTname       ¦ ¦ Data class
-#  -zX           ¦«¦ Use default name for "X"
+#  -zAname       ï¿½ ï¿½ Code class
+#  -zBname       ï¿½ ï¿½ BSS class
+#  -zCname       ï¿½ ï¿½ Code segment
+#  -zDname       ï¿½ ï¿½ BSS segment
+#  -zEname       ï¿½ ï¿½ Far segment
+#  -zFname       ï¿½ ï¿½ Far class
+#  -zGname       ï¿½ ï¿½ BSS group
+#  -zHname       ï¿½ ï¿½ Far group
+#  -zPname       ï¿½ ï¿½ Code group
+#  -zRname       ï¿½ ï¿½ Data segment
+#  -zSname       ï¿½ ï¿½ Data group
+#  -zTname       ï¿½ ï¿½ Data class
+#  -zX           ï¿½ï¿½ï¿½ Use default name for "X"
 
 #
 # ALLCFLAGS specified by turbo.cfg and config.mak

--- a/mkfiles/turbocpp.mak
+++ b/mkfiles/turbocpp.mak
@@ -4,11 +4,28 @@
 
 # Use these for Turbo CPP 1.01
 
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KTP
+
+TARGETOPT=-1-
+!if $(XCPU) == 186
+TARGETOPT=-1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(TP1_BASE)
 COMPILERBIN=$(COMPILERPATH)\bin
 CC=$(COMPILERBIN)\tcc -c
 CL=$(COMPILERBIN)\tcc
-INCLUDEPATH=$(COMPILERPATH)\include
+INCLUDEPATH1=-I$(COMPILERPATH)\include
 LIBUTIL=$(COMPILERBIN)\tlib
 LIBPATH=$(COMPILERPATH)\lib
 LIBTERM=  
@@ -17,8 +34,6 @@ LIBPLUS=+
 TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
-
-TARGET=KTP
 
 # used for building the library
 
@@ -31,19 +46,19 @@ MATH_INSERT=+H_LDIV +H_LLSH +H_LURSH +F_LXMUL
 # Compiler and Options for Borland C++
 # ------------------------------------
 #
-#  -zAname       ¦ ¦ Code class
-#  -zBname       ¦ ¦ BSS class
-#  -zCname       ¦ ¦ Code segment
-#  -zDname       ¦ ¦ BSS segment
-#  -zEname       ¦ ¦ Far segment
-#  -zFname       ¦ ¦ Far class
-#  -zGname       ¦ ¦ BSS group
-#  -zHname       ¦ ¦ Far group
-#  -zPname       ¦ ¦ Code group
-#  -zRname       ¦ ¦ Data segment
-#  -zSname       ¦ ¦ Data group
-#  -zTname       ¦ ¦ Data class
-#  -zX           ¦«¦ Use default name for "X"
+#  -zAname       ï¿½ ï¿½ Code class
+#  -zBname       ï¿½ ï¿½ BSS class
+#  -zCname       ï¿½ ï¿½ Code segment
+#  -zDname       ï¿½ ï¿½ BSS segment
+#  -zEname       ï¿½ ï¿½ Far segment
+#  -zFname       ï¿½ ï¿½ Far class
+#  -zGname       ï¿½ ï¿½ BSS group
+#  -zHname       ï¿½ ï¿½ Far group
+#  -zPname       ï¿½ ï¿½ Code group
+#  -zRname       ï¿½ ï¿½ Data segment
+#  -zSname       ï¿½ ï¿½ Data group
+#  -zTname       ï¿½ ï¿½ Data class
+#  -zX           ï¿½ï¿½ï¿½ Use default name for "X"
 
 #
 # ALLCFLAGS specified by turbo.cfg and config.mak

--- a/mkfiles/watcom.mak
+++ b/mkfiles/watcom.mak
@@ -3,18 +3,30 @@
 #
 
 # Use these for WATCOM 11.0c
+
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KWC
+
+TARGETOPT=-0
+!if $(XCPU) == 186
+TARGETOPT=-1
+ALLCFLAGS=$(ALLCFLAGS) -DI186
+!endif
+!if $(XCPU) == 386
+TARGETOPT=-3
+ALLCFLAGS=$(ALLCFLAGS) -DI386
+!endif
+
 COMPILERPATH=$(WATCOM)
 CC=*wcc -zq
 CL=wcl -zq
-INCLUDEPATH=$(COMPILERPATH)\H
+INCLUDEPATH=$(COMPILERPATH)\h
 INCLUDE=$(COMPILERPATH)\h 
 EDPATH=$(COMPILERPATH)\EDDAT
-
-!if $(XCPU) != 186
-!if $(XCPU) != 386
-TARGETOPT=-0
-!endif
-!endif
 
 LIBPATH=$(COMPILERPATH)\lib286
 LIBUTIL=wlib -q 
@@ -24,8 +36,6 @@ LIBTERM=
 TINY=-mt
 CFLAGST=-zp1-os-s-we-e3-wx-bt=DOS
 CFLAGSC=-mc-zp1-os-s-we-e3-wx-bt=DOS
-
-TARGET=KWC
 
 # used for building the library
 

--- a/sys/makefile
+++ b/sys/makefile
@@ -6,7 +6,7 @@
 
 !include "../mkfiles/generic.mak"
 
-CFLAGS = -I$(INCLUDEPATH) -I..$(DIRSEP)hdr -DFORSYS -DWITHFAT32 $(CFLAGST)
+CFLAGS = -I..$(DIRSEP)hdr $(INCLUDEPATH1) -DFORSYS -DWITHFAT32 $(CFLAGST)
 NASMFLAGS = -DSYS=1
 
 #		*List Macros*
@@ -21,7 +21,7 @@ SYS_EXE_dependencies =  \
 production:     bin2c.exe ../bin/sys.com
 
 bin2c.exe:      bin2c.c
-		$(CLC) bin2c.c
+		$(CLC) $(INCLUDEPATH2) bin2c.c
 
 ../bin/sys.com: sys.com
 		$(CP) sys.com ..$(DIRSEP)bin
@@ -48,8 +48,10 @@ prf.obj:	../kernel/prf.c
 		$(CC) $(CFLAGS) ..$(DIRSEP)kernel$(DIRSEP)prf.c
 
 fdkrncfg.obj:   fdkrncfg.c ../hdr/kconfig.h
+		$(CC) $(CFLAGS) fdkrncfg.c
 
 talloc.obj:     talloc.c
+		$(CC) $(CFLAGS) talloc.c
 
 sys.com:        $(SYS_EXE_dependencies)
 		$(CL) $(CFLAGST) $(TINY) $(SYS_EXE_dependencies)
@@ -62,5 +64,5 @@ clean:
 
 #		*Individual File Dependencies*
 sys.obj: sys.c ../hdr/portab.h ../hdr/device.h fat12com.h fat16com.h fat32chs.h fat32lba.h oemfat12.h oemfat16.h
-		$(CC) $(CFLAGS) $*.c
+		$(CC) $(CFLAGS) sys.c
 

--- a/utils/makefile
+++ b/utils/makefile
@@ -1,6 +1,6 @@
 !include "../mkfiles/generic.mak"
 
-CFLAGS = -I..$(DIRSEP)hdr
+CFLAGS = -I..$(DIRSEP)hdr $(INCLUDEPATH2)
 
 production: patchobj.com exeflat.exe upxentry.bin upxdevic.bin
 


### PR DESCRIPTION

- move TARGET related macros to toolchain related makefiles
- move CPU related setup to toolchain related makefiles

Notes: not all make utilities behave same that some construct cannot be used only stupid hardcoded names works OK
!! environment variables is not created from macros if not exist in environment !!
it is wmake and nmake behaviour, if appropriate tool is not configured (env. variables not exist) then you must use command line parameters to work correctly
if we want to work in any situation then command line parameters is necessary
now it is fixed for INCLUDE/INCLUDEPATH macros that appropriate values are passed by command line
other macros/env.vars must be fixed too (LIBPATH, LIB, ...), but it is not issue for gcc and mostly for OW