### PR TITLE
ow-build: add global compiler control option to CC and CL macros

### DIFF
--- a/mkfiles/owlinux.mak
+++ b/mkfiles/owlinux.mak
@@ -6,14 +6,14 @@
 include "../mkfiles/watcom.mak"
 
 DIRSEP=/
+CC=$(CC) -fo=.obj
+CL=$(CL) -fo=.obj
 INCLUDEPATH=$(COMPILERPATH)/h
 RM=rm -f
 CP=cp
 ECHOTO=echo>>
 INITPATCH=@echo > /dev/null
 CLDEF=1
-CLT=wcl386 -zq -bcl=linux -I../hdr -fe=$@ -I$(COMPILERPATH)/lh
+CLT=wcl386 -zq -fo=.obj -bcl=linux -I../hdr -fe=$@ -I$(COMPILERPATH)/lh
 CLC=$(CLT)
-CFLAGST=-fo=.obj $(CFLAGST)
-ALLCFLAGS=-fo=.obj $(ALLCFLAGS) 
-XLINK=$(XLINK) debug all op symfile format dos option map,statics,verbose F { $(OBJS) } L ../lib/device.lib N kernel.exe $#
+XLINK=$(XLINK) debug all format dos opt quiet,symfile,map,statics,verbose F { $(OBJS) } L ../lib/device.lib N kernel.exe $#

--- a/mkfiles/owwin.mak
+++ b/mkfiles/owwin.mak
@@ -15,7 +15,5 @@ INCLUDEPATH=$(COMPILERPATH)\h
 CLDEF=1
 CLT=wcl386 -zq -bcl=nt -I..\hdr -fe=$@ -I$(COMPILERPATH)\h -I$(COMPILERPATH)\h\nt
 CLC=$(CLT)
-CFLAGST=-fo=.obj $(CFLAGST)
-ALLCFLAGS=-fo=.obj $(ALLCFLAGS) 
 NASMFLAGS=-DWATCOM $(NASMFLAGS)
-#XLINK=$(XLINK) debug all op symfile format dos option map,statics,verbose F { $(OBJS) } L ..$(DIRSEP)lib$(DIRSEP)device.lib N kernel.exe $#
+XLINK=$(XLINK) debug all format dos opt quiet,symfile,map,statics,verbose F { $(OBJS) } L ..$(DIRSEP)lib$(DIRSEP)device.lib N kernel.exe $#

--- a/mkfiles/watcom.mak
+++ b/mkfiles/watcom.mak
@@ -4,8 +4,8 @@
 
 # Use these for WATCOM 11.0c
 COMPILERPATH=$(WATCOM)
-CC=*wcc
-CL=wcl
+CC=*wcc -zq
+CL=wcl -zq
 INCLUDEPATH=$(COMPILERPATH)\H
 INCLUDE=$(COMPILERPATH)\h 
 EDPATH=$(COMPILERPATH)\EDDAT
@@ -22,8 +22,8 @@ LIBPLUS=
 LIBTERM=
 
 TINY=-mt
-CFLAGST=-zq-zp1-os-s-we-e3-wx-bt=DOS
-CFLAGSC=-mc-zq-zp1-os-s-we-e3-wx-bt=DOS
+CFLAGST=-zp1-os-s-we-e3-wx-bt=DOS
+CFLAGSC=-mc-zp1-os-s-we-e3-wx-bt=DOS
 
 TARGET=KWC
 
@@ -61,7 +61,7 @@ MATH_INSERT=+i4m
 # -3		optimization for 386 - given in CONFIG.MAK, not here
 #
 
-ALLCFLAGS=-I..$(DIRSEP)hdr $(TARGETOPT) $(ALLCFLAGS) -zq-os-s-e5-j-zl-zp1-wx-we-zgf-zff-r
+ALLCFLAGS=-I..$(DIRSEP)hdr $(TARGETOPT) $(ALLCFLAGS) -os-s-e5-j-zl-zp1-wx-we-zgf-zff-r
 INITCFLAGS=$(ALLCFLAGS)-ntINIT_TEXT-gTGROUP-ndI
 CFLAGS=$(ALLCFLAGS)-ntHMA_TEXT
 


### PR DESCRIPTION
move only options which is related to the host environment not for target
-zq quiet output (all)
-fo=.obj set default extension for object file to .obj instead .o (Linux only)