### PR TITLE
far-fix: symbols BIOSInt13, UserInt13 and BIOSInt19 are far (in LGROUP)

### DIFF
--- a/hdr/win.h
+++ b/hdr/win.h
@@ -21,7 +21,7 @@ extern struct WinStartupInfo winStartupInfo;
 #if defined __GNUC__
 extern UWORD winseg1, winseg2, winseg3;
 extern UBYTE markEndInstanceData;
-extern struct lol ASM FAR DATASTART;
+extern struct lol FAR ASM DATASTART;
 #endif
 
 

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -261,7 +261,7 @@ extern struct lol FAR *LoL;
 extern struct dhdr DOSTEXTFAR ASM blk_dev; /* Block device (Disk) driver           */
 
 extern struct buffer FAR *DOSFAR firstAvailableBuf; /* first 'available' buffer   */
-extern struct lol ASM FAR DATASTART;
+extern struct lol FAR ASM DATASTART;
 
 extern BYTE DOSFAR ASM _HMATextAvailable;    /* first byte of available CODE area    */
 extern BYTE FAR ASM _HMATextStart[];          /* first byte of HMAable CODE area      */

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1914,7 +1914,9 @@ struct int2f12regs {
   UWORD callerARG1;             /* used if called from INT2F/12 */
 };
 
-extern intvec ASM BIOSInt13, ASM UserInt13, ASM BIOSInt19;
+extern intvec FAR ASM BIOSInt13;
+extern intvec FAR ASM UserInt13;
+extern intvec FAR ASM BIOSInt19;
 
 
 /* WARNING: modifications in `r' are used outside of int2F_12_handler()


### PR DESCRIPTION
these symbols are in LGROUP and generaly cannot be addressed by DGROUP:offset
for Turbo C DGROUP offset overflow because symbols are too far to be addressed by DGROUP offset