### PR TITLE
libm.lib: The i4m module from OW-CRTL is no longer used

### DIFF
--- a/mkfiles/watcom.mak
+++ b/mkfiles/watcom.mak
@@ -34,8 +34,8 @@ CLIB=$(COMPILERPATH)\lib286\dos\clibm.lib
 # we use our own ones, which override these ones when linking.
 #  
 
-MATH_EXTRACT=*i4m
-MATH_INSERT=+i4m
+MATH_EXTRACT=
+MATH_INSERT=
 
 
 #


### PR DESCRIPTION
now FreeDOS own implementation is used
this module is removed from the library to prevent misuse of this module