### PR TITLE
ecm boot no cr

### DIFF
--- a/kernel/config.c
+++ b/kernel/config.c
@@ -1085,14 +1085,15 @@ STATIC BOOL SkipLine(char *pLine)
 {
   short key;
   COUNT i;
+  signed char originalskipconfigseconds = InitKernelConfig.SkipConfigSeconds;
 
-  if (InitKernelConfig.SkipConfigSeconds >= 0)
+  if (originalskipconfigseconds >= 0)
   {
 
-    if (InitKernelConfig.SkipConfigSeconds > 0)
+    if (originalskipconfigseconds > 0)
       printf("Press F8 to trace or F5 to skip CONFIG.SYS/AUTOEXEC.BAT");
 
-    key = GetBiosKey(InitKernelConfig.SkipConfigSeconds);       /* wait 2 seconds */
+    key = GetBiosKey(originalskipconfigseconds);       /* wait 2 seconds */
 
     InitKernelConfig.SkipConfigSeconds = -1;
 
@@ -1105,7 +1106,8 @@ STATIC BOOL SkipLine(char *pLine)
       singleStep = TRUE;
     }
 
-    printf("\r%79s\r", "");     /* clear line */
+    if (originalskipconfigseconds > 0)
+      printf("\r%79s\r", "");     /* clear line */
 
     if (SkipAllConfig)
       printf("Skipping CONFIG.SYS/AUTOEXEC.BAT\n");

--- a/kernel/initdisk.c
+++ b/kernel/initdisk.c
@@ -618,7 +618,7 @@ void DosDefinePartition(struct DriveParamS *driveParam,
       ExtPri = "Ext";
       num = extendedPartNo;
     }
-    printf("\r%c: HD%d, %s[%2d]", 'A' + nUnits,
+    printf("%c: HD%d, %s[%2d]", 'A' + nUnits,
            (driveParam->driveno & 0x7f) + 1, ExtPri, num);
 
     printCHS(", CHS= ", &chs);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -440,15 +440,15 @@ STATIC VOID signon()
 	if (InitKernelConfig.Verbose < 0) 
 	{
 #ifdef CUSTOM_BRANDING
-        printf("\n\r" CUSTOM_BRANDING "\n\n");
+        printf("\n" CUSTOM_BRANDING "\n\n");
 #else
-        printf("\n\r%S\n\n", MK_FP(FP_SEG(LoL), FP_OFF(LoL->os_release)));
+        printf("\n%S\n\n", MK_FP(FP_SEG(LoL), FP_OFF(LoL->os_release)));
 #endif
 	} else {
 #ifdef CUSTOM_BRANDING
-  printf("\n\r" CUSTOM_BRANDING "\n\n%s", copyright);
+  printf("\n" CUSTOM_BRANDING "\n\n%s", copyright);
 #else
-  printf("\r%S"
+  printf("\n%S"
          "Kernel compatibility %d.%d - "
 #if defined(__BORLANDC__)
   "BORLANDC"


### PR DESCRIPTION
This PR eliminates lone Carriage Returns used by the kernel, if SWITCHES=/F or SWITCHES=/N is used in fdconfig.sys. Reason: They annoy me in dosemu2 output when redirected into a file.