### PR TITLE
fix 2F.4A MS-DOS v5 style HMA access services

### DIFF
--- a/kernel/blockio.c
+++ b/kernel/blockio.c
@@ -500,7 +500,7 @@ void AllocateHMASpace (size_t lowbuffer, size_t highbuffer)
   do
   {
     /* check if buffer intersects with requested area                  */
-    if (FP_OFF(bp) < highbuffer && FP_OFF(bp+1) > lowbuffer)
+    if (FP_OFF(bp) <= highbuffer && FP_OFF(bp+1) > lowbuffer)
     {
       flush1(bp);
       /* unlink bp from buffer chain */

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1953,12 +1953,13 @@ VOID ASMCFUNC int2F_12_handler(struct int2f12regs FAR *pr)
             size = 0;
             offs = 0xffff;			/* requested more than we have */
           } else {
+            UWORD alignment = offs - realoffs;
             size = (UWORD)requestedsize;	/* return rounded size */
             AllocateHMASpace(realoffs, offs + size - 1); /* ! realoffs */
             if ( ((UDWORD)offs + (UDWORD)size) == 0x10000UL ) {
               firstAvailableBuf = MK_FP(0xFFFF, 0xFFFF); /* exhausted */
             } else {
-              firstAvailableBuf += size; /* advance free pointer */
+              firstAvailableBuf += size + alignment; /* advance free pointer */
             }
           }
         }


### PR DESCRIPTION
* Reject allocation call with too large requested size, rather than allocating the remaining HMA.
* Align returned offset to paragraph boundary.
* Allow to allocate up to the very last byte of the HMA, rather than 1 byte less.
* Pass last allocated byte to AllocateHMASpace instead of the byte past it, which would carry for a full allocation.