### PR TITLE
CI: Update to use Ubuntu 24.04 runner

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     if: contains(github.event.head_commit.message, '[skip ci]') == false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository and submodules


### PR DESCRIPTION
Now that the ia16-gcc compiler is available on Ubuntu Noble we can update the runner.