### PR TITLE
boot32.asm: fix, reset full ax after int 10h function 0Eh

### DIFF
--- a/boot/boot32.asm
+++ b/boot/boot32.asm
@@ -223,7 +223,7 @@ c6:
 boot_error:
 		mov ax, 0E00h | '!'
 		int 10h				; display the error sign
-		mov al, 07h
+		mov ax, 0E07h
 		int 10h				; beep
 		xor	ah,ah
 		int	0x16			; wait for a key


### PR DESCRIPTION
We discovered [1] that some ROM-BIOS implementations apparently corrupt the ah register contents upon running int 10h function 0Eh so that writing only al afterwards isn't certain to set up the registers for another function 0Eh call.

In the talk about this I referenced an earlier problem [2] in which it was the al register, not ah, which got corrupted. So all in all the int 10h function 0Eh call should be expected to clobber the entirety of ax, alongside bp. (The bp corruption is stated in the Interrupt List [3].)

[1]: https://github.com/SvarDOS/bugz/issues/174#issuecomment-3368497819
[2]: https://github.com/FDOS/kernel/commit/977023f85c701d740260ccffea373d333cce676e
[3]: https://fd.lod.bz/rbil/interrup/video/100e.html