### PR TITLE
initdisk.c: work around Xi8088 ROM-BIOS bug for int 13.41 [fixes #156]

### DIFF
--- a/kernel/initdisk.c
+++ b/kernel/initdisk.c
@@ -652,6 +652,10 @@ STATIC int LBA_Get_Drive_Parameters(int drive, struct DriveParamS *driveParam, i
   regs.b.x = 0x55aa;
   regs.a.b.h = 0x41;
   regs.d.b.l = drive;
+  regs.ds = 0x40;
+  /* ds = 40h is to work around a Xi8088 ROM-BIOS bug,
+      refer to https://github.com/FDOS/kernel/issues/156
+      and https://www.bttr-software.de/forum/forum_entry.php?id=21275 */
   regs.flags = FLG_CARRY;  /* ensure carry is set to force error if unsupported */
 
   init_call_intr(0x13, &regs);


### PR DESCRIPTION
Setting ds = 40h for int 13h function 41h is to work around a Xi8088 ROM-BIOS bug. All LBA extensions functions are affected, but only the detection call will reach the bug code because that BIOS reports that it doesn't support the LBA extensions.

Refer to https://github.com/FDOS/kernel/issues/156 and https://www.bttr-software.de/forum/forum_entry.php?id=21275