### PR TITLE
sys.c: in _dos_findfirst set DTA rather than copying from PSP:80h, and work around Xi8088 ROM-BIOS bug (13.41 ds=40h)

### DIFF
--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1293,7 +1293,11 @@ BOOL haveLBA(void);     /* return TRUE if we have LBA BIOS, FALSE otherwise */
       "mov ax, 0x4100"  /* IBM/MS Int 13h Extensions - installation check */ \
       "mov bx, 0x55AA" \
       "mov dl, 0x80"   \
+      "push ds"        \
+      "mov cx, 0x40"   \
+      "mov ds, cx"     \
       "int 0x13"       \
+      "pop ds"         \
       "xor ax, ax"     \
       "cmp bx, 0xAA55" \
       "jne quit"       \


### PR DESCRIPTION
Running prior to this commit, a /K switch with a name at a certain position will write all-blanks into the boot sector loader. If that happens, lDOS instsect will not detect a valid load file name:

```
C:\>sys a: /bootonly /k ldos.com
System transferred.

C:\>instsect /bo a:
Detected FAT12 FS.
Keeping original sector loader.
Sector valid, FS ID match and proper jump.
Type heuristic: "FreeDOS (FreeDOS)"
No name detected.
Unit selection code not found in sector. Keeping as is.
Part info code not found in sector. Keeping as is.
Query geometry code not found in sector. Keeping as is.
Auto LBA detection (HDD only) found in sector. Keeping as is.
Previous geometry: 2 CHS Heads, 18 CHS Sectors, 0 Hidden
Writing boot sector to sector.
C:\>
```

Running after this commit sets the name as desired:

```
C:\>sys a: /bootonly /k ldos.com
System transferred.

C:\>instsect /bo a:
Detected FAT12 FS.
Keeping original sector loader.
Sector valid, FS ID match and proper jump.
Type heuristic: "FreeDOS (FreeDOS)"
1st name: "LDOS.COM"
Unit selection code not found in sector. Keeping as is.
Part info code not found in sector. Keeping as is.
Query geometry code not found in sector. Keeping as is.
Auto LBA detection (HDD only) found in sector. Keeping as is.
Previous geometry: 2 CHS Heads, 18 CHS Sectors, 0 Hidden
Writing boot sector to sector.
C:\>
```

For reference, the libi86 implementation of _dos_findfirst also sets the DTA to the user buffer rather than copying around the resulting search record. So it is likely that Turbo C or Watcom do it similarly to this:

https://gitlab.com/tkchia/libi86/-/blob/3ecc4164999a5807c40cf2c159dc94dd07f7df03/host-gcc/dos/dos-findfirst.c#L43

(I may add a commit addressing https://github.com/FDOS/kernel/issues/156 to this PR later.)