### PR TITLE
IOCTL: Add int21/4408 is drive removable

### DIFF
--- a/kernel/ioctl.c
+++ b/kernel/ioctl.c
@@ -184,7 +184,7 @@ int DosDevIOctl(lregs * r)
       }
       else
       {
-        if (r->AL != 9)
+        if (r->AL != 8 && r->AL != 9)
           return DE_INVLDDRV;
         dev = NULL;
         attr = ATTR_REMOTE;
@@ -192,6 +192,16 @@ int DosDevIOctl(lregs * r)
 
       switch (r->AL)
       {
+	case 0x08:
+	{
+	  struct cds FAR *cdsp = get_cds1(r->BL & 0x1f);
+	  if (cdsp == NULL)
+	    return DE_INVLDDRV;
+	  if (cdsp->cdsFlags & CDSNETWDRV)
+	    return DE_INVLDFUNC;
+	  r->AX = (dpbp->dpb_flags == M_DONT_KNOW);
+	  return SUCCESS;
+	}
         case 0x09:
         {
           /* note from get_dpb()                            */
@@ -213,7 +223,7 @@ int DosDevIOctl(lregs * r)
             return SUCCESS;
           }
           /* fall through */
-        default: /* 0x04, 0x05, 0x08, 0x0e, 0x0f, 0x11 */
+        default: /* 0x04, 0x05, 0x0e, 0x0f, 0x11 */
           break;
       }
       break;


### PR DESCRIPTION
I have added a test to the dosemu2 test suite for int21/4408 (is drive removable). Here are the results for

| MS-DOS 6.22 | FreeDOS with this patch |
| --- | --- |
| C:\>REM - FAT16 | C:\>REM - FAT16 |
| C:\>C:\drvremov d:                            | C:\>C:\drvremov d:|
| Drive D: fixed |Drive D: fixed |
|||
|C:\>REM - MFS network | C:\>REM - MFS network|
|C:\>C:\drvremov C:|C:\>C:\drvremov C:|
|Drive C: ERROR: 0x0001|Drive C: ERROR: 0x0001|
|||
|C:\>REM - FAT12 floppy|C:\>REM - FAT12 floppy|
|C:\>C:\drvremov A:|C:\>C:\drvremov A:|
|Drive A: removable|Drive A: removable|
|||
|C:\>REM - phantom floppy|C:\>REM - phantom floppy|
|C:\>C:\drvremov B:|C:\>C:\drvremov B:|
|Drive B: removable|Drive B: removable|
|||
|C:\>REM - non existent device|C:\>REM - non existent device|
|C:\>C:\drvremov X:|C:\>C:\drvremov X:|
|Drive X: ERROR: 0x000f|Drive X: ERROR: 0x000f|

With the same drive setup as above (A: floppy, B:phantom floppy, C:MFS remote/network, D: FAT16 image) I didn't get the result (fixed/removable status) I expected from Jerome's drvdiag program regarding floppies  [see #227] , but seeing as the results above are identical to MS-DOS 6.22, I don't see what's wrong.

~~~
C:\>drvdiag
DrvUtils (2021-08-26)
(a programmer's disk diagnostic utility, work in progress)

INT 11          Floppy Present: TRUE
MEM 0040:0075   Total Fixed Drives: 0x05
INT 13,08       Drive 0x00: TRUE
                type: 1.44M, 0x04 [00700x011E]
                drives: 0x01
                0x01 heads, 0x12 sectors, 0x004F cylinders
INT 13,08       Drive 0x01: BIOS Error #1: invalid request to controller
INT 13,08       Drive 0x02: BIOS Error #1: invalid request to controller
INT 13,08       Drive 0x80: TRUE
                drives: 0x05
                0x03 heads, 0x11 sectors, 0x0131 cylinders
INT 13,08       Drive 0x81: TRUE
                drives: 0x05
                0x07 heads, 0x20 sectors, 0x0145 cylinders
INT 13,08       Drive 0x82: TRUE
                drives: 0x05
                0xFE heads, 0x3F sectors, 0x00FE cylinders
INT 13,08       Drive 0x83: TRUE
                drives: 0x05
                0xFE heads, 0x3F sectors, 0x00FE cylinders
INT 13,08       Drive 0x84: TRUE
                drives: 0x05
                0xFE heads, 0x3F sectors, 0x00FE cylinders
INT 13,08       Drive 0x85: BIOS Error #1: invalid request to controller

Drive A:
INT 21,4408     Removable: false
INT 21,4409     Remote flags: none 
Drive C:
INT 21,4408     Removable: DOS Error #1: invalid function number
INT 21,4409     Remote flags: 0x1000 Is Remote 
Drive D:
INT 21,4408     Removable: false
INT 21,4409     Remote flags: none 
Drive E:
INT 21,4408     Removable: DOS Error #1: invalid function number
INT 21,4409     Remote flags: 0x1000 Is Remote 
Drive F:
INT 21,4408     Removable: DOS Error #1: invalid function number
INT 21,4409     Remote flags: 0x1000 Is Remote 
Drive G:
INT 21,4408     Removable: DOS Error #1: invalid function number
INT 21,4409     Remote flags: 0x1000 Is Remote 
Drive H:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive I:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive J:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive K:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive L:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive M:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive N:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive O:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive P:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive Q:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive R:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive S:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive T:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive U:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive V:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive W:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive X:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive Y:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 
Drive Z:
INT 21,4408     Removable: DOS Error #15: invalid drive
INT 21,4409     Remote flags: DOS Error #15: invalid drive 

INT 2F,1500     CD-ROM Drives: not present
Done for now. :-)
~~~
