### PR TITLE
CI: Downcase TARGET variable

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -16,7 +16,7 @@ mkdir _output/gcc
 git clean -x -d -f -e test -e _output -e _downloads -e _watcom
 make -C country clean
 make all COMPILER=gcc
-mv -n bin/KGC*.map bin/KGC*.sys _output/gcc/.
+mv -n bin/kgc*.map bin/kgc*.sys _output/gcc/.
 mv -n bin/country.sys _output/gcc/.
 # GCC share
 (
@@ -36,7 +36,7 @@ mkdir _output/wc
 git clean -x -d -f -e test -e _output -e _downloads -e _watcom
 make -C country clean
 make all COMPILER=owlinux
-mv -n bin/KWC*.map bin/KWC*.sys _output/wc/.
+mv -n bin/kwc*.map bin/kwc*.sys _output/wc/.
 mv -n bin/country.sys _output/wc/.
 
 ## DOS (GCC)
@@ -71,7 +71,7 @@ git clean -x -d -f -e test -e _output -e _downloads -e _watcom
 } | unix2dos > config.bat
 
 dosemu -td -q -K . -E "build.bat"
-mv -n bin/KWC*.map bin/KWC*.sys _output/wc_dos/.
+mv -n bin/kwc*.map bin/kwc*.sys _output/wc_dos/.
 mv -n bin/country.sys _output/wc_dos/.
 
 
@@ -91,7 +91,7 @@ if [ -d ${HOME}/.dosemu/drive_c/tc201 ] ; then
   } | unix2dos > config.bat
 
   dosemu -td -q -K . -E "build.bat"
-  mv -n bin/KTC*.map bin/KTC*.sys _output/tc_dos/.
+  mv -n bin/ktc*.map bin/ktc*.sys _output/tc_dos/.
   mv -n bin/country.sys _output/tc_dos/.
   # TC share
   (

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -2,22 +2,22 @@
 
 KVER=8632
 
-if [ ! -f _output/gcc/KGC${KVER}.sys ] ; then
+if [ ! -f _output/gcc/kgc${KVER}.sys ] ; then
   echo GCC built kernel not present
   exit 1
 fi
 
-if [ ! -f _output/wc/KWC${KVER}.sys ] ; then
+if [ ! -f _output/wc/kwc${KVER}.sys ] ; then
   echo Watcom built kernel not present
   exit 1
 fi
 
-if [ ! -f _output/wc_dos/KWC38632.sys ] ; then
+if [ ! -f _output/wc_dos/kwc38632.sys ] ; then
   echo Watcom DOS built kernel not present
   exit 1
 fi
 
-if [ ! -f _output/tc_dos/KTC8632.sys ] && [ -d ${HOME}/.dosemu/drive_c/tc201 ] ; then
+if [ ! -f _output/tc_dos/ktc8632.sys ] && [ -d ${HOME}/.dosemu/drive_c/tc201 ] ; then
   echo Turbo C 2.01 built kernel not present
   exit 1
 fi
@@ -26,23 +26,23 @@ echo Kernels have all been built
 find _output -ls
 
 cd test
-if ! ./test.sh ../_output/gcc/KGC${KVER}.sys diskgc bootgc 'boot gcc: '
+if ! ./test.sh ../_output/gcc/kgc${KVER}.sys diskgc bootgc 'boot gcc: '
 then
   echo GCC boot test failed
   exit 2
 fi
-if ! ./test.sh ../_output/wc/KWC${KVER}.sys diskwc bootwc 'boot wc: '
+if ! ./test.sh ../_output/wc/kwc${KVER}.sys diskwc bootwc 'boot wc: '
 then
   echo OpenWatcom boot test failed
   exit 2
 fi
-if ! ./test.sh ../_output/wc_dos/KWC38632.sys diskwcd bootwcd 'boot wcd: '
+if ! ./test.sh ../_output/wc_dos/kwc38632.sys diskwcd bootwcd 'boot wcd: '
 then
   echo 'OpenWatcom(DOS) boot test failed'
   exit 2
 fi
 if [ -d ${HOME}/.dosemu/drive_c/tc201 ] ; then
-  if ! ./test.sh ../_output/tc_dos/KTC8632.sys disktcd boottcd 'boot tcd: '
+  if ! ./test.sh ../_output/tc_dos/ktc8632.sys disktcd boottcd 'boot tcd: '
   then
     echo 'Turbo C 2.01 boot test failed'
     exit 2

--- a/mkfiles/bc3.mak
+++ b/mkfiles/bc3.mak
@@ -18,7 +18,7 @@ TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
 
-TARGET=KT3
+TARGET=kt3
 
 # used for building the library
 

--- a/mkfiles/bc5.mak
+++ b/mkfiles/bc5.mak
@@ -18,7 +18,7 @@ TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
 
-TARGET=KBC
+TARGET=kbc
 
 # used for building the library
 

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -7,7 +7,7 @@
 #* TARGETOPT : options, handled down to the compiler
 #**********************************************************************
 
-TARGET=KGC$(XCPU)$(XFAT)
+TARGET=kgc$(XCPU)$(XFAT)
 TARGETOPT=-march=i8086
 
 ifeq ($(XCPU),186)

--- a/mkfiles/mscl8.mak
+++ b/mkfiles/mscl8.mak
@@ -34,7 +34,7 @@ TARGETOPT=-G1
 TARGETOPT=-G3
 !endif
 
-TARGET=KMS
+TARGET=kms
 
 #
 # heavy stuff - building

--- a/mkfiles/tc2.mak
+++ b/mkfiles/tc2.mak
@@ -18,7 +18,7 @@ TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d -w
 CFLAGSC=-L$(LIBPATH) -a- -mc
 
-TARGET=KTC
+TARGET=ktc
 
 # used for building the library
 

--- a/mkfiles/tc3.mak
+++ b/mkfiles/tc3.mak
@@ -18,7 +18,7 @@ TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
 
-TARGET=KT3
+TARGET=kt3
 
 # used for building the library
 

--- a/mkfiles/turbocpp.mak
+++ b/mkfiles/turbocpp.mak
@@ -18,7 +18,7 @@ TINY=-lt
 CFLAGST=-L$(LIBPATH) -mt -a- -k- -f- -ff- -O -Z -d
 CFLAGSC=-L$(LIBPATH) -a- -mc
 
-TARGET=KTP
+TARGET=ktp
 
 # used for building the library
 

--- a/mkfiles/watcom.mak
+++ b/mkfiles/watcom.mak
@@ -25,7 +25,7 @@ TINY=-mt
 CFLAGST=-zp1-os-s-we-e3-wx-bt=DOS
 CFLAGSC=-mc-zp1-os-s-we-e3-wx-bt=DOS
 
-TARGET=KWC
+TARGET=kwc
 
 # used for building the library
 


### PR DESCRIPTION
The main reason for this is so the filenames are downcased on Linux systems such as the CI, which has the benefit of not creating mixed case filenames within the Actions output zip. On Windows and DOS systems there will be no appreciable difference seen as fileystems there are either case insensitive or case preserving.