### PR TITLE
fatfs.c: update dir_size during map_cluster extend loop [fixes #241]

### DIFF
--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1028,6 +1028,12 @@ COUNT map_cluster(REG f_node_ptr fnp, COUNT mode)
 
     fnp->f_cluster = cluster;
     fnp->f_cluster_offset++;
+    fnp->f_dir.dir_size =
+      ((ULONG)fnp->f_cluster
+      * (ULONG)fnp->f_dpb->dpb_secsize)
+      <<
+      fnp->f_dpb->dpb_shftcnt;
+    merge_file_changes(fnp, FALSE);
   }
 
 #ifdef DISPLAY_GETBLOCK


### PR DESCRIPTION
Problem discussed in https://github.com/FDOS/kernel/issues/241 With this fix, the partial extend loop updates the directory entry's file size field after allocating every cluster so that the final result is a file properly allocated all clusters left free prior.

To consider: Is `map_cluster` used by directory code? Will have to re-order this then so that subdirectories aren't given a nonzero size.