### PR TITLE
add Intel syntax alternatives to all gcc inline assembly

### DIFF
--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -162,7 +162,7 @@ static inline void enable(void)
 static inline unsigned short getCS(void)
 {
   unsigned short ret;
-  asm volatile("mov %%cs, %0" : "=r"(ret));
+  asm volatile("{ mov %%cs, %0 | mov %0, cs }" : "=r"(ret));
   return ret;
 }
 
@@ -170,7 +170,7 @@ static inline unsigned short getCS(void)
 static inline unsigned short getSS(void)
 {
   unsigned short ret;
-  asm volatile("mov %%ss, %0" : "=r"(ret));
+  asm volatile("{ mov %%ss, %0 | mov %0, ss }" : "=r"(ret));
   return ret;
 }
 extern char DosDataSeg[];

--- a/kernel/chario.c
+++ b/kernel/chario.c
@@ -152,7 +152,7 @@ STATIC void fast_put_char(unsigned char chr)
     _AL = chr;
     __int__(0x29);
 #elif defined(__GNUC__)
-    asm volatile("int $0x29":: "a"(chr):"bx");
+    asm volatile("{ int $0x29 | int 0x29 }":: "a"(chr):"bx");
 #elif defined(I86)
     asm
     {

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -178,7 +178,7 @@ VOID ASMCFUNC int21_syscall(iregs FAR * irp)
 #if !defined __GNUC__ || defined  __IA16_FEATURE_ATTRIBUTE_NO_ASSUME_SS_DATA
           irp->DX = FP_SEG(os_release);
 #else  /* TODO: remove this hacky SS != DGROUP workaround  --tkchia 20191207 */
-          asm volatile("movw %%ds, %0" : "=g" (irp->DX));
+          asm volatile("{ movw %%ds, %0 | mov %0, ds }" : "=g" (irp->DX));
 #endif
           irp->AX = FP_OFF(os_release);
       }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -840,7 +840,7 @@ STATIC void CheckContinueBootFromHarddisk(void)
 
   {
 #if __GNUC__
-    asm volatile("jmp $0,$0x7c00");
+    asm volatile("{ jmp $0,$0x7c00 | jmp 0,0x7c00 }"::);
 #else
     void (far *reboot)(void) = (void (far*)(void)) MK_FP(0x0,0x7c00);
 

--- a/kernel/prf.c
+++ b/kernel/prf.c
@@ -75,7 +75,7 @@ void put_console(int c)
     __int__(0xe6);
 #elif defined(__GNUC__)
     asm volatile(
-      "int $0xe6\n"
+      "{ int $0xe6 | int 0xe6 }"
       : /* outputs */
       : /* inputs */ "a"(0x13), "e"(FP_SEG(buff)), "d"(FP_OFF(buff))
     );
@@ -126,7 +126,7 @@ void put_console(int c)
   fastComPrint(c);
 #endif
 #elif defined(__GNUC__)
-  asm volatile("int $0x29" : : "a"(c) : "bx");
+  asm volatile("{ int $0x29 | int 0x29 }" : : "a"(c) : "bx");
 #elif defined(I86)
   __asm
   {

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -108,14 +108,25 @@ struct _diskfree_t {
 int int86x(int ivec, union REGS *in, union REGS *out, struct SREGS *s)
 {
   /* must save sp for int25/26 */
-  asm("mov %7, %%cs:(1f+1); jmp 0f; 0:"
+  asm("{"
+      "mov %7, %%cs:(1f+1); jmp 0f; 0:"
       "mov %%di, %%dx; mov %%sp, %%di;"
       "push %%di; push %%di;"
       /* push twice to work both for int 25h/26h and int 21h */
       "1:int $0x00; pop %%di; pop %%di;"
       /* second pop always reads the correct SP value.
          the first pop may read the FL left on stack. */
-      "mov %%di, %%sp; sbb %0, %0" :
+      "mov %%di, %%sp; sbb %0, %0;"
+      " | "
+      "mov byte ptr cs:[1f+1], %7; jmp 0f; 0:"
+      "mov dx, di; mov di, sp;"
+      "push di; push di;"
+      /* push twice to work both for int 25h/26h and int 21h */
+      "1:int 0x00; pop di; pop di;"
+      /* second pop always reads the correct SP value.
+         the first pop may read the FL left on stack. */
+      "mov sp, di; sbb %0, %0;"
+      "}" :
       "=r"(out->x.cflag),
       "=a"(out->x.ax), "=b"(out->x.bx), "=c"(out->x.cx), "=d"(out->x.dx),
       "=e"(s->es), "=Rds"(s->ds) :
@@ -140,7 +151,11 @@ int intdos(union REGS *in, union REGS *out)
 
 int intdosx(union REGS *in, union REGS *out, struct SREGS *s)
 {
-  asm("push %%ds; mov %%bx, %%ds; int $0x21; pop %%ds; sbb %0, %0":
+  asm("{"
+      "push %%ds; mov %%bx, %%ds; int $0x21; pop %%ds; sbb %0, %0\n"
+      " | "
+      "push ds; mov ds, bx; int 0x21; pop ds; sbb %0, %0\n"
+      "}" :
       "=r"(out->x.cflag), "=a"(out->x.ax) :
       "a"(in->x.ax), "c"(in->x.cx), "d"(in->x.dx),
       "D"(in->x.di), "S"(in->x.si), "b"(s->ds), "e"(s->es) :


### PR DESCRIPTION
Based on https://github.com/FDOS/kernel/discussions/225 I developed the patch in https://pushbx.org/ecm/test/20260422-generate-listings.diff (AT&T syntax) and https://pushbx.org/ecm/test/20260422-generate-listings-intel.diff (Intel syntax) to generate assembler listing files from the .c files.

This commit includes only the changes to inline assembly, as these shouldn't break anything for other users or other compilers than ia16-elf-gcc. As it turns out, gcc extended inline assembly allows to specify two variants for any snippet, one for AT&T syntax and the other for Intel syntax.

Previously discussed in https://codeberg.org/tkchia/gcc-ia16/issues/9#issuecomment-13551167

I verified that both sys.com and kgc8632.sys are byte by byte exactly identicalised matches before and after applying this commit.