### PR TITLE
ecm fix fix partial extend

### DIFF
--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1029,7 +1029,7 @@ COUNT map_cluster(REG f_node_ptr fnp, COUNT mode)
     fnp->f_cluster = cluster;
     fnp->f_cluster_offset++;
     fnp->f_dir.dir_size =
-      ((ULONG)fnp->f_cluster
+      (((ULONG)fnp->f_cluster_offset + 1)
       * (ULONG)fnp->f_dpb->dpb_secsize)
       <<
       fnp->f_dpb->dpb_shftcnt;

--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1218,9 +1218,21 @@ long rwblock(COUNT fd, VOID FAR * buffer, UCOUNT count, int mode)
     
     if (dos_extend(fnp) != SUCCESS)
     {
+      /* ecm: control flow may end up here if CX = 0000h and
+                the extending failed to allocate a cluster
+                behind the last needed. in this case, our
+                return here of 0 happens to be correct and
+                indicates the extension succeeded. */
       fnode_to_sft(fnp);
       return 0;
     }
+    /* ecm: if CX = 0000h and seek was on a cluster boundary > size,
+                the dos_extend call will have allocated one cluster
+                too many. this is truncated later without problems.
+                but does this aid fragmentation maybe ?
+            if CX > 0000h then we want to write to the cluster
+                anyway, so extending to the cluster that starts at
+                the boundary is desired. */
   }
   
   /* Test that we are really about to do a data transfer. If the  */


### PR DESCRIPTION
Fixes https://github.com/FDOS/kernel/issues/243 and properly fixes https://github.com/FDOS/kernel/issues/241

This updates the commit from https://github.com/FDOS/kernel/pull/242 with a correction.

I also added two comments on unexpected corner cases around writes of length 0 trying to extend more than actually needed. There is possibly a fragmentation source if a file is extended to fall exactly on a cluster boundary with 0-length write.