### PR TITLE
fatfs.c: fix to the fix to the fix, only write file size if appended

### DIFF
--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1024,16 +1024,21 @@ COUNT map_cluster(REG f_node_ptr fnp, COUNT mode)
       cluster = extend(fnp);
       if (cluster == LONG_LAST_CLUSTER)
         return DE_HNDLDSKFULL;
+
+      /* ecm: finally the right solution, only extend/modify
+                file size after having just appended a cluster. */
+      fnp->f_dir.dir_size =
+        (((ULONG)fnp->f_cluster_offset + 2)
+        /* at 0 we will increment to 1, having allocated the second
+                cluster, so + 2 for the then-total size. */
+        * (ULONG)fnp->f_dpb->dpb_secsize)
+        <<
+        fnp->f_dpb->dpb_shftcnt;
+      merge_file_changes(fnp, FALSE);
     }
 
     fnp->f_cluster = cluster;
     fnp->f_cluster_offset++;
-    fnp->f_dir.dir_size =
-      (((ULONG)fnp->f_cluster_offset + 1)
-      * (ULONG)fnp->f_dpb->dpb_secsize)
-      <<
-      fnp->f_dpb->dpb_shftcnt;
-    merge_file_changes(fnp, FALSE);
   }
 
 #ifdef DISPLAY_GETBLOCK


### PR DESCRIPTION
[The prior revision](https://github.com/FDOS/kernel/pull/245) incorrectly corrupted the file size even if just scanning the file, including for read. Move the code so it only runs after the very spot that found it is writing, needed to append a new cluster to the chain, and successfully did do that.

Script for lDebug file to test this error:

```
=== testtrun.sld
e 200 "A:\test.dat" 0
f 400 l 400 38
a
 mov ah, 3C
 mov cx, 0
 mov dx, 200
 int 21
 xchg bx, ax
 mov ax, 4200
 mov cx, (#10240 >> 10)
 mov dx, (#10240 & FFFF)
 int 21
 mov ah, 40
 mov dx, 400
 mov cx, 0
 int 21
 mov ah, 68
 int 21
 nop
 mov ax, 4200
 xor cx, cx
 xor dx, dx
 int 21
 mov dx, 800
 mov ah, 3F
 mov cx, 380
 int 21
 int3
 mov ah, 68
 int 21
 nop
 int3
 nop
 jmp 100
 .
===
```