### PR TITLE
ecm fix 4 dos extend map fail

### DIFF
--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1024,17 +1024,6 @@ COUNT map_cluster(REG f_node_ptr fnp, COUNT mode)
       cluster = extend(fnp);
       if (cluster == LONG_LAST_CLUSTER)
         return DE_HNDLDSKFULL;
-
-      /* ecm: finally the right solution, only extend/modify
-                file size after having just appended a cluster. */
-      fnp->f_dir.dir_size =
-        (((ULONG)fnp->f_cluster_offset + 2)
-        /* at 0 we will increment to 1, having allocated the second
-                cluster, so + 2 for the then-total size. */
-        * (ULONG)fnp->f_dpb->dpb_secsize)
-        <<
-        fnp->f_dpb->dpb_shftcnt;
-      merge_file_changes(fnp, FALSE);
     }
 
     fnp->f_cluster = cluster;
@@ -1075,8 +1064,21 @@ STATIC COUNT dos_extend(f_node_ptr fnp)
   while (count > 0)
 #endif
   {
-    if (map_cluster(fnp, XFR_WRITE) != SUCCESS)
+    if (map_cluster(fnp, XFR_WRITE) != SUCCESS) {
+      if (fnp->f_cluster != FREE) {
+        /* ecm: write size if couldn't satisfy full request,
+                but at least one cluster is allocated. */
+        fnp->f_dir.dir_size =
+          (((ULONG)fnp->f_cluster_offset + 1)
+          /* at 0 we have incremented to 1, having allocated the second
+                cluster, so + 1 for the then-total size. */
+          * (ULONG)fnp->f_dpb->dpb_secsize)
+          <<
+          fnp->f_dpb->dpb_shftcnt;
+        merge_file_changes(fnp, FALSE);
+      }
       return DE_HNDLDSKFULL;
+    }
 
 #ifdef WRITEZEROS
     /* Compute the block within the cluster and the offset  */
@@ -1106,6 +1108,18 @@ STATIC COUNT dos_extend(f_node_ptr fnp)
     }
     if (bp == NULL)
     {
+      if (fnp->f_cluster != FREE) {
+        /* ecm: write size if couldn't satisfy full request,
+                but at least one cluster is allocated. */
+        fnp->f_dir.dir_size =
+          (((ULONG)fnp->f_cluster_offset + 1)
+          /* at 0 we have incremented to 1, having allocated the second
+                cluster, so + 1 for the then-total size. */
+          * (ULONG)fnp->f_dpb->dpb_secsize)
+          <<
+          fnp->f_dpb->dpb_shftcnt;
+        merge_file_changes(fnp, FALSE);
+      }
       return DE_ACCESS;
     }
 

--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1066,7 +1066,11 @@ STATIC COUNT dos_extend(f_node_ptr fnp, BOOL emptywrite)
   {
     BOOL special = 0;
     if (emptywrite
-        /* && fnp->f_offset != 0 */ /* always true here */
+#ifdef WRITEZEROS
+        && fnp->f_offset != 0
+#else
+        /* f_offset != 0 always true here */
+#endif
         && ((fnp->f_offset &
              (((ULONG)fnp->f_dpb->dpb_secsize
                << fnp->f_dpb->dpb_shftcnt) - 1)

--- a/kernel/fatfs.c
+++ b/kernel/fatfs.c
@@ -1044,7 +1044,7 @@ COUNT map_cluster(REG f_node_ptr fnp, COUNT mode)
 /* #define WRITEZEROS 1                                        */
 /* but because we want to be compatible, we don't do this by   */
 /* default                                                     */
-STATIC COUNT dos_extend(f_node_ptr fnp)
+STATIC COUNT dos_extend(f_node_ptr fnp, BOOL emptywrite)
 {
 #ifdef WRITEZEROS
   struct buffer FAR *bp;
@@ -1064,7 +1064,20 @@ STATIC COUNT dos_extend(f_node_ptr fnp)
   while (count > 0)
 #endif
   {
+    BOOL special = 0;
+    if (emptywrite
+        /* && fnp->f_offset != 0 */ /* always true here */
+        && ((fnp->f_offset &
+             (((ULONG)fnp->f_dpb->dpb_secsize
+               << fnp->f_dpb->dpb_shftcnt) - 1)
+            )
+            == 0)
+        ) {
+      special = 1;
+      -- fnp->f_offset;
+    }
     if (map_cluster(fnp, XFR_WRITE) != SUCCESS) {
+      if (special) ++ fnp->f_offset;
       if (fnp->f_cluster != FREE) {
         /* ecm: write size if couldn't satisfy full request,
                 but at least one cluster is allocated. */
@@ -1079,6 +1092,7 @@ STATIC COUNT dos_extend(f_node_ptr fnp)
       }
       return DE_HNDLDSKFULL;
     }
+    if (special) ++ fnp->f_offset;
 
 #ifdef WRITEZEROS
     /* Compute the block within the cluster and the offset  */
@@ -1235,7 +1249,7 @@ long rwblock(COUNT fd, VOID FAR * buffer, UCOUNT count, int mode)
     /* mark file as modified and set date not valid any more */
     fnp->f_flags &= ~(SFT_FCLEAN|SFT_FDATE); 
     
-    if (dos_extend(fnp) != SUCCESS)
+    if (dos_extend(fnp, count == 0) != SUCCESS)
     {
       /* ecm: control flow may end up here if CX = 0000h and
                 the extending failed to allocate a cluster


### PR DESCRIPTION
Another take on https://github.com/FDOS/kernel/issues/241 and a related question in https://github.com/FDOS/kernel/pull/245 which reads:

> I also added two comments on unexpected corner cases around writes of length 0 trying to extend more than actually needed. There is possibly a fragmentation source if a file is extended to fall exactly on a cluster boundary with 0-length write